### PR TITLE
Add the option to filter by any attribute

### DIFF
--- a/lib/metadata/metadata.js
+++ b/lib/metadata/metadata.js
@@ -43,44 +43,41 @@ function Metadata(columns) {
 
 
 /**
- * Get an array of all columns, optionally filtering by status.
- * @param {string|undefined} status The status to filter by. The status options
- *     are 'public' or 'deprecated'. Not setting a status returns all coluns.
- * @return {Array} A list of column passing the status filter.
+ * Returns an array of all columns, with an optional filter applied.
+ * @param {Object|Function} filter An optional filter object or function.
+ *     If an object is passed, all property values must match. If a function is
+ *     passed, it is invoked with the column's attributes object and the
+ *     the column will be included if the function returns true.
+ * @return {Array} A list of columns passing the filter.
  */
-Metadata.prototype.all = function(status) {
-  return !status ? this._columns : this._columns.filter(function(column) {
-    return column.attributes.status.toLowerCase() === status.toLowerCase();
-  });
+Metadata.prototype.all = function(filter) {
+  return filter ? applyFilter(this._columns, filter) : this._columns;
 };
 
 
 /**
- * Get an array of all metrics, optionally filtering by status.
- * @param {string|undefined} status The status to filter by. The status
- *     options are 'public' or 'deprecated'. Not setting a status returns all
- *     metrics.
- * @return {Array} A list of column passing the status filter.
+ * Returns an array of all metric columns, with an optional filter applied.
+ * @param {Object|Function} filter An optional filter object or function.
+ *     If an object is passed, all property values must match. If a function is
+ *     passed, it is invoked with the column's attributes object and the
+ *     the column will be included if the function returns true.
+ * @return {Array} A list of metric columns passing the filter.
  */
-Metadata.prototype.allMetrics = function(status) {
-  return !status ? this._metrics : this._metrics.filter(function(metric) {
-    return metric.attributes.status.toLowerCase() === status.toLowerCase();
-  });
+Metadata.prototype.allMetrics = function(filter) {
+  return filter ? applyFilter(this._metrics, filter) : this._metrics;
 };
 
 
 /**
- * Get an array of all dimensions, optionally filtering by status.
- * @param {string|undefined} status The status to filter by. The status
- *     options are 'public' or 'deprecated'. Not setting a status returns all
- *     dimensions.
- * @return {Array} A list of column passing the status filter.
+ * Returns an array of all dimension columns, with an optional filter applied.
+ * @param {Object|Function} filter An optional filter object or function.
+ *     If an object is passed, all property values must match. If a function is
+ *     passed, it is invoked with the column's attributes object and the
+ *     the column will be included if the function returns true.
+ * @return {Array} A list of dimension columns passing the filter.
  */
-Metadata.prototype.allDimensions = function(status) {
-  return !status ?
-      this._dimensions : this._dimensions.filter(function(dimension) {
-    return dimension.attributes.status.toLowerCase() === status.toLowerCase();
-  });
+Metadata.prototype.allDimensions = function(filter) {
+  return filter ? applyFilter(this._dimensions, filter) : this._dimensions;
 };
 
 
@@ -92,6 +89,30 @@ Metadata.prototype.allDimensions = function(status) {
 Metadata.prototype.get = function(id) {
   return this._ids[id];
 };
+
+
+/**
+ * Returns a list of metadata columns passing a filter.
+ * @param {Array} columns The list of metadata columns.
+ * @param {Object|Function} filter An object or function filter.
+ *     If an object is passed, all property values must exactly match the
+ *     corresponding column attributes. If a function is passed, it is invoked
+ *     with the column's attributes object and the the column will be included
+ *     if the function returns true.
+ * @return {Array} The new columns after the filter has been applied.
+ */
+function applyFilter(columns, filter) {
+  return columns.filter(function(column) {
+    if (typeof filter == 'function') {
+      return filter(column.attributes);
+    }
+    else {
+      return Object.keys(filter).every(function(key) {
+        return filter[key] === column.attributes[key];
+      });
+    }
+  });
+}
 
 
 module.exports = Metadata;

--- a/test/_fixtures/metadata-authenticated-premium.json
+++ b/test/_fixtures/metadata-authenticated-premium.json
@@ -1,7 +1,7 @@
 {
   "kind": "analytics#columns",
-  "etag": "\"gUXd2oJOIvAWr2KnYegR9N0sJ7c/Duhub3vzRGEQ1SK4h3jlmcENHac\"",
-  "totalResults": 424,
+  "etag": "\"RTuqIyS1Tt5XEFy6I77L5pEAbZQ/lwy4jM_fkWuurrzNQQUx_Pg44Yc\"",
+  "totalResults": 476,
   "attributeNames": [
     "replacedBy",
     "type",
@@ -16,7 +16,8 @@
     "maxTemplateIndex",
     "premiumMinTemplateIndex",
     "premiumMaxTemplateIndex",
-    "allowedInSegments"
+    "allowedInSegments",
+    "addedInApiVersion"
   ],
   "items": [
     {
@@ -28,8 +29,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "User Type",
-        "description": "A boolean indicating if a user is new or returning. Possible values: New Visitor, Returning Visitor.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either New Visitor or Returning Visitor, indicating if the users are new or returning.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -42,8 +44,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "User Type",
-        "description": "A boolean indicating if a user is new or returning. Possible values: New Visitor, Returning Visitor.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either New Visitor or Returning Visitor, indicating if the users are new or returning.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -55,8 +58,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Count of Sessions",
-        "description": "The session index for a user to your property. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indicies. For example, if a certain user has 4 sessions to your website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
-        "allowedInSegments": "true"
+        "description": "The session index for a user. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indices. For example, if a user has 4 sessions to the website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -69,8 +73,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Count of Sessions",
-        "description": "The session index for a user to your property. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indicies. For example, if a certain user has 4 sessions to your website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
-        "allowedInSegments": "true"
+        "description": "The session index for a user. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indices. For example, if a user has 4 sessions to the website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -82,8 +87,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Days Since Last Session",
-        "description": "The number of days elapsed since users last visited your property. Used to calculate user loyalty.",
-        "allowedInSegments": "true"
+        "description": "The number of days elapsed since users last visited the property, used to calculate user loyalty.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -96,8 +102,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Days Since Last Session",
-        "description": "The number of days elapsed since users last visited your property. Used to calculate user loyalty.",
-        "allowedInSegments": "true"
+        "description": "The number of days elapsed since users last visited the property, used to calculate user loyalty.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -109,8 +116,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "User Defined Value",
-        "description": "The value provided when you define custom user segments for your property.",
-        "allowedInSegments": "true"
+        "description": "The value provided when defining custom user segments for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -122,7 +130,8 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Users",
-        "description": "Total number of users to your property for the requested time period."
+        "description": "The total number of users for the requested time period.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -135,7 +144,8 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Users",
-        "description": "Total number of users to your property for the requested time period."
+        "description": "The total number of users for the requested time period.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -147,8 +157,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "New Users",
-        "description": "The number of users whose session on your property was marked as a first-time session.",
-        "allowedInSegments": "true"
+        "description": "The number of users whose session was marked as a first-time session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -161,8 +172,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "New Users",
-        "description": "The number of users whose session on your property was marked as a first-time session.",
-        "allowedInSegments": "true"
+        "description": "The number of users whose session was marked as a first-time session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -174,8 +186,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "% New Sessions",
-        "description": "The percentage of sessions by people who had never visited your property before.",
-        "calculation": "ga:newUsers / ga:sessions"
+        "description": "The percentage of sessions by users who had never visited the property before.",
+        "calculation": "ga:newUsers / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -188,8 +201,61 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "% New Sessions",
-        "description": "The percentage of sessions by people who had never visited your property before.",
-        "calculation": "ga:newUsers / ga:sessions"
+        "description": "The percentage of sessions by users who had never visited the property before.",
+        "calculation": "ga:newUsers / ga:sessions",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:1dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "1 Day Active Users",
+        "description": "Total number of 1-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 1-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:7dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "7 Day Active Users",
+        "description": "Total number of 7-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 7-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:14dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "14 Day Active Users",
+        "description": "Total number of 14-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 14-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:30dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "30 Day Active Users",
+        "description": "Total number of 30-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 30-day period ending on the given date.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -201,8 +267,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Session Duration",
-        "description": "The length of a session on your property measured in seconds and reported in second increments. The value returned is a string.",
-        "allowedInSegments": "true"
+        "description": "The length (returned as a string) of a session measured in seconds and reported in second increments.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -215,8 +282,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Session Duration",
-        "description": "The length of a session on your property measured in seconds and reported in second increments. The value returned is a string.",
-        "allowedInSegments": "true"
+        "description": "The length (returned as a string) of a session measured in seconds and reported in second increments.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -228,8 +296,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Sessions",
-        "description": "Counts the total number of sessions.",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -242,8 +311,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Sessions",
-        "description": "Counts the total number of sessions.",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -255,8 +325,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Bounces",
-        "description": "The total number of single page (or single engagement hit) sessions for your property.",
-        "allowedInSegments": "true"
+        "description": "The total number of single page (or single engagement hit) sessions for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -270,7 +341,8 @@
         "status": "DEPRECATED",
         "uiName": "Bounce Rate",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:bounceRate instead.",
-        "calculation": "ga:bounces / ga:entrances"
+        "calculation": "ga:bounces / ga:entrances",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -282,8 +354,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Bounce Rate",
-        "description": "The percentage of single-page session (i.e., session in which the person left your property from the first page).",
-        "calculation": "ga:bounces / ga:sessions"
+        "description": "The percentage of single-page session (i.e., session in which the person left the property from the first page).",
+        "calculation": "ga:bounces / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -296,8 +369,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Bounce Rate",
-        "description": "The percentage of single-page session (i.e., session in which the person left your property from the first page).",
-        "calculation": "ga:bounces / ga:sessions"
+        "description": "The percentage of single-page session (i.e., session in which the person left the property from the first page).",
+        "calculation": "ga:bounces / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -309,8 +383,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Session Duration",
-        "description": "The total duration of user sessions represented in total seconds.",
-        "allowedInSegments": "true"
+        "description": "Total duration (in seconds) of users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -323,8 +398,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Session Duration",
-        "description": "The total duration of user sessions represented in total seconds.",
-        "allowedInSegments": "true"
+        "description": "Total duration (in seconds) of users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -336,8 +412,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Avg. Session Duration",
-        "description": "The average duration of user sessions represented in total seconds.",
-        "calculation": "ga:sessionDuration / ga:sessions"
+        "description": "The average duration (in seconds) of users' sessions.",
+        "calculation": "ga:sessionDuration / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -350,8 +427,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Avg. Session Duration",
-        "description": "The average duration of user sessions represented in total seconds.",
-        "calculation": "ga:sessionDuration / ga:sessions"
+        "description": "The average duration (in seconds) of users' sessions.",
+        "calculation": "ga:sessionDuration / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -363,8 +441,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Referral Path",
-        "description": "The path of the referring URL (e.g. document.referrer). If someone places a link to your property on their website, this element contains the path of the page that contains the referring link.",
-        "allowedInSegments": "true"
+        "description": "The path of the referring URL (e.g., document.referrer). If someone places on their webpage a link to the property, this is the path of the page containing the referring link.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -376,7 +455,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Full Referrer",
-        "description": "The full referring URL including the hostname and path."
+        "description": "The full referring URL including the hostname and path.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -388,8 +468,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Campaign",
-        "description": "When using manual campaign tracking, the value of the utm_campaign campaign tracking parameter. When using AdWords autotagging, the name(s) of the online ad campaign that you use for your property. Otherwise the value (not set) is used.",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_campaign campaign tracking parameter. For AdWords autotagging, it is the name(s) of the online ad campaign(s) you use for the property. If you use neither, its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -401,8 +482,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Source",
-        "description": "The source of referrals to your property. When using manual campaign tracking, the value of the utm_source campaign tracking parameter. When using AdWords autotagging, the value is google. Otherwise the domain of the source referring the user to your property (e.g. document.referrer). The value may also contain a port address. If the user arrived without a referrer, the value is (direct)",
-        "allowedInSegments": "true"
+        "description": "The source of referrals. For manual campaign tracking, it is the value of the utm_source campaign tracking parameter. For AdWords autotagging, it is google. If you use neither, it is the domain of the source (e.g., document.referrer) referring the users. It may also contain a port address. If users arrived without a referrer, its value is (direct).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -414,8 +496,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Medium",
-        "description": "The type of referrals to your property. When using manual campaign tracking, the value of the utm_medium campaign tracking parameter. When using AdWords autotagging, the value is ppc. If the user comes from a search engine detected by Google Analytics, the value is organic. If the referrer is not a search engine, the value is referral. If the users came directly to the property, and document.referrer is empty, the value is (none).",
-        "allowedInSegments": "true"
+        "description": "The type of referrals. For manual campaign tracking, it is the value of the utm_medium campaign tracking parameter. For AdWords autotagging, it is ppc. If users came from a search engine detected by Google Analytics, it is organic. If the referrer is not a search engine, it is referral. If users came directly to the property and document.referrer is empty, its value is (none).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -428,7 +511,8 @@
         "status": "PUBLIC",
         "uiName": "Source / Medium",
         "description": "Combined values of ga:source and ga:medium.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -440,8 +524,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Keyword",
-        "description": "When using manual campaign tracking, the value of the utm_term campaign tracking parameter. When using AdWords autotagging or if a user used organic search to reach your property, the keywords used by users to reach your property. Otherwise the value is (not set).",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_term campaign tracking parameter. For AdWords autotagging or when users use organic search to reach the property, it contains the keywords used to reach the property. Otherwise its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -453,8 +538,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Ad Content",
-        "description": "When using manual campaign tracking, the value of the utm_content campaign tracking parameter. When using AdWords autotagging, the first line of the text for your online Ad campaign. If you are using mad libs for your AdWords content, this field displays the keywords you provided for the mad libs keyword match. Otherwise the value is (not set)",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_campaign campaign tracking parameter. For AdWords autotagging, it is the first line of the text for the online Ad campaign. If you use mad libs for the AdWords content, it contains the keywords you provided for the mad libs keyword match. If you use none of the above, its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -466,7 +552,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Social Network",
-        "description": "Name of the social network. This can be related to the referring social network for traffic sources, or to the social network for social data hub activities. E.g. Google+, Blogger, etc."
+        "description": "The social network name. This can be related to the referring social network for traffic sources, or to the social network for social data hub activities; e.g., Google+, Blogger.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -478,7 +565,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Social Source Referral",
-        "description": "Indicates sessions that arrived to the property from a social source. The possible values are Yes or No where the first letter is capitalized."
+        "description": "A boolean, either Yes or No, indicates whether sessions to the property are from a social source.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -490,7 +578,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Organic Searches",
-        "description": "The number of organic searches that happened within a session. This metric is search engine agnostic."
+        "description": "The number of organic searches happened in a session. This metric is search engine agnostic.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -502,8 +591,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Group",
-        "description": "The name of your AdWords ad group.",
-        "allowedInSegments": "true"
+        "description": "The name of the AdWords ad group.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -515,8 +605,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Slot",
-        "description": "The location of the advertisement on the hosting page (Top, RHS, or not set).",
-        "allowedInSegments": "true"
+        "description": "The location (Top, RHS, or not set) of the advertisement on the hosting page.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -526,10 +617,11 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Adwords",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Ad Slot Position",
-        "description": "The ad slot positions in which your AdWords ads appeared (1-8).",
-        "allowedInSegments": "true"
+        "description": "This dimension is deprecated and will soon be removed.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -541,7 +633,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Distribution Network",
-        "description": "The networks used to deliver your ads (Content, Search, Search partners, etc.)."
+        "description": "The network (Content, Search, Search partners, etc.) used to deliver the ads.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -553,7 +646,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Query Match Type",
-        "description": "The match types applied for the search term the user had input(Phrase, Exact, Broad, etc.). Ads on the content network are identified as \"Content network\". Details: https://support.google.com/adwords/answer/2472708?hl=en"
+        "description": "The match type (Phrase, Exact, Broad, etc.) applied for users' search term. Ads on the content network are identified as \"Content network\". For details, see https://support.google.com/adwords/answer/2472708?hl=en.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -565,7 +659,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Keyword Match Type",
-        "description": "The match types applied to your keywords (Phrase, Exact, Broad). Details: https://support.google.com/adwords/answer/2472708?hl=en"
+        "description": "The match type (Phrase, Exact, or Broad) applied to the keywords. For details, see https://support.google.com/adwords/answer/2472708.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -577,7 +672,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Matched Search Query",
-        "description": "The search queries that triggered impressions of your AdWords ads."
+        "description": "The search query that triggered impressions of the AdWords ads.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -589,7 +685,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement Domain",
-        "description": "The domains where your ads on the content network were placed."
+        "description": "The domain where the ads on the content network were placed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -601,7 +698,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement URL",
-        "description": "The URLs where your ads on the content network were placed."
+        "description": "The URL where the ads were placed on the content network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -613,7 +711,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Format",
-        "description": "Your AdWords ad formats (Text, Image, Flash, Video, etc.)."
+        "description": "The AdWords ad format (Text, Image, Flash, Video, etc.).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -625,7 +724,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Targeting Type",
-        "description": "How your AdWords ads were targeted (keyword, placement, and vertical targeting, etc.)."
+        "description": "This (keyword, placement, or vertical targeting) indicates how the AdWords ads were targeted.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -637,7 +738,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement Type",
-        "description": "How you manage your ads on the content network. Values are Automatic placements or Managed placements."
+        "description": "It is Automatic placements or Managed placements, indicating how the ads were managed on the content network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -649,7 +751,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Display URL",
-        "description": "The URLs your AdWords ads displayed."
+        "description": "The URL the AdWords ads displayed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -661,7 +764,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Destination URL",
-        "description": "The URLs to which your AdWords ads referred traffic."
+        "description": "The URL to which the AdWords ads referred traffic.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -673,7 +777,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Customer ID",
-        "description": "A string. Corresponds to AdWords API AccountInfo.customerId."
+        "description": "Customer's AdWords ID, corresponding to AdWords API AccountInfo.customerId.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -685,7 +790,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Campaign ID",
-        "description": "A string. Corresponds to AdWords API Campaign.id."
+        "description": "AdWords API Campaign.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -697,7 +803,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Ad Group ID",
-        "description": "A string. Corresponds to AdWords API AdGroup.id."
+        "description": "AdWords API AdGroup.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -709,7 +816,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Creative ID",
-        "description": "A string. Corresponds to AdWords API Ad.id."
+        "description": "AdWords API Ad.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -721,7 +829,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Criteria ID",
-        "description": "A string. Corresponds to AdWords API Criterion.id."
+        "description": "AdWords API Criterion.id. The geographical targeting Criteria IDs are listed at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -733,7 +842,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Impressions",
-        "description": "Total number of campaign impressions."
+        "description": "Total number of campaign impressions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -745,7 +855,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Clicks",
-        "description": "The total number of times users have clicked on an ad to reach your property."
+        "description": "Total number of times users have clicked on an ad to reach the property.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -757,7 +868,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost",
-        "description": "Derived cost for the advertising campaign. The currency for this value is based on the currency that you set in your AdWords account."
+        "description": "Derived cost for the advertising campaign. Its currency is the one you set in the AdWords account.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -770,7 +882,8 @@
         "status": "PUBLIC",
         "uiName": "CPM",
         "description": "Cost per thousand impressions.",
-        "calculation": "ga:adCost / (ga:impressions / 1000)"
+        "calculation": "ga:adCost / (ga:impressions / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -783,7 +896,8 @@
         "status": "PUBLIC",
         "uiName": "CPC",
         "description": "Cost to advertiser per click.",
-        "calculation": "ga:adCost / ga:adClicks"
+        "calculation": "ga:adCost / ga:adClicks",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -795,8 +909,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "CTR",
-        "description": "Click-through-rate for your ad. This is equal to the number of clicks divided by the number of impressions for your ad (e.g. how many times users clicked on one of your ads where that ad appeared).",
-        "calculation": "ga:adClicks / ga:impressions"
+        "description": "Click-through-rate for the ad. This is equal to the number of clicks divided by the number of impressions for the ad (e.g., how many times users clicked on one of the ads where that ad appeared).",
+        "calculation": "ga:adClicks / ga:impressions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -808,8 +923,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Transaction",
-        "description": "The cost per transaction for your property.",
-        "calculation": "(ga:adCost) / (ga:transactions)"
+        "description": "The cost per transaction for the property.",
+        "calculation": "(ga:adCost) / (ga:transactions)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -821,8 +937,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Goal Conversion",
-        "description": "The cost per goal conversion for your property.",
-        "calculation": "(ga:adCost) / (ga:goalCompletionsAll)"
+        "description": "The cost per goal conversion for the property.",
+        "calculation": "(ga:adCost) / (ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -834,8 +951,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Conversion",
-        "description": "The cost per conversion (including ecommerce and goal conversions) for your property.",
-        "calculation": "(ga:adCost) / (ga:transactions  +  ga:goalCompletionsAll)"
+        "description": "The cost per conversion (including ecommerce and goal conversions) for the property.",
+        "calculation": "(ga:adCost) / (ga:transactions  +  ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -847,8 +965,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "RPC",
-        "description": "RPC or revenue-per-click is the average revenue (from ecommerce sales and/or goal value) you received for each click on one of your search ads.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adClicks"
+        "description": "RPC or revenue-per-click, the average revenue (from ecommerce sales and/or goal value) you received for each click on one of the search ads.",
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adClicks",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -861,7 +980,8 @@
         "status": "DEPRECATED",
         "uiName": "ROI",
         "description": "This metric is deprecated and will be removed soon. Please use ga:ROAS instead.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / ga:adCost"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / ga:adCost",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -874,7 +994,8 @@
         "status": "DEPRECATED",
         "uiName": "Margin",
         "description": "This metric is deprecated and will be removed soon. Please use ga:ROAS instead.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / (ga:transactionRevenue + ga:goalValueAll)"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / (ga:transactionRevenue + ga:goalValueAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -887,7 +1008,21 @@
         "status": "PUBLIC",
         "uiName": "ROAS",
         "description": "Return On Ad Spend (ROAS) is the total transaction revenue and goal value divided by derived advertising cost.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adCost"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adCost",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adQueryWordCount",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Adwords",
+        "status": "PUBLIC",
+        "uiName": "Query Word Count",
+        "description": "The number of words in the search query.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -899,7 +1034,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Completion Location",
-        "description": "The page path or screen name that matched any destination type goal completion."
+        "description": "The page path or screen name that matched any destination type goal completion.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -911,7 +1047,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 1",
-        "description": "The page path or screen name that matched any destination type goal, one step prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, one step prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -923,7 +1060,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 2",
-        "description": "The page path or screen name that matched any destination type goal, two steps prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, two steps prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -935,7 +1073,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 3",
-        "description": "The page path or screen name that matched any destination type goal, three steps prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, three steps prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -950,7 +1089,8 @@
         "description": "The total number of starts for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -965,7 +1105,8 @@
         "description": "The total number of starts for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -980,7 +1121,8 @@
         "description": "The total number of starts for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -992,8 +1134,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Starts",
-        "description": "The total number of starts for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total number of starts for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1008,7 +1151,8 @@
         "description": "The total number of completions for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1023,7 +1167,8 @@
         "description": "The total number of completions for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1038,7 +1183,8 @@
         "description": "The total number of completions for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1050,8 +1196,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Completions",
-        "description": "The total number of completions for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total number of completions for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1066,7 +1213,8 @@
         "description": "The total numeric value for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1081,7 +1229,8 @@
         "description": "The total numeric value for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1096,7 +1245,8 @@
         "description": "The total numeric value for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1108,8 +1258,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Value",
-        "description": "The total numeric value for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total numeric value for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1121,8 +1272,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Per Session Goal Value",
-        "description": "The average goal value of a session on your property.",
-        "calculation": "ga:goalValueAll / ga:sessions"
+        "description": "The average goal value of a session.",
+        "calculation": "ga:goalValueAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1135,8 +1287,9 @@
         "group": "Goal Conversions",
         "status": "DEPRECATED",
         "uiName": "Per Session Goal Value",
-        "description": "The average goal value of a session on your property.",
-        "calculation": "ga:goalValueAll / ga:sessions"
+        "description": "The average goal value of a session.",
+        "calculation": "ga:goalValueAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1148,10 +1301,11 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Checkout complete (Goal 1 Conversion Rate)",
-        "description": "The percentage of sessions which resulted in a conversion to the requested goal number.",
+        "description": "Percentage of sessions resulting in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:sessions",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1163,10 +1317,11 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Create an account (Goal 2 Conversion Rate)",
-        "description": "The percentage of sessions which resulted in a conversion to the requested goal number.",
+        "description": "Percentage of sessions resulting in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:sessions",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1178,10 +1333,11 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Find store location (Goal 3 Conversion Rate)",
-        "description": "The percentage of sessions which resulted in a conversion to the requested goal number.",
+        "description": "Percentage of sessions resulting in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:sessions",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1193,8 +1349,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Conversion Rate",
-        "description": "The percentage of sessions which resulted in a conversion to at least one of your goals.",
-        "calculation": "ga:goalCompletionsAll / ga:sessions"
+        "description": "The percentage of sessions which resulted in a conversion to at least one of the goals.",
+        "calculation": "ga:goalCompletionsAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1209,7 +1366,8 @@
         "description": "The number of times users started conversion activity on the requested goal number without actually completing it.",
         "calculation": "(ga:goalXXStarts - ga:goalXXCompletions)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1224,7 +1382,8 @@
         "description": "The number of times users started conversion activity on the requested goal number without actually completing it.",
         "calculation": "(ga:goalXXStarts - ga:goalXXCompletions)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1239,7 +1398,8 @@
         "description": "The number of times users started conversion activity on the requested goal number without actually completing it.",
         "calculation": "(ga:goalXXStarts - ga:goalXXCompletions)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1252,7 +1412,8 @@
         "status": "PUBLIC",
         "uiName": "Abandoned Funnels",
         "description": "The overall number of times users started goals without actually completing them.",
-        "calculation": "(ga:goalStartsAll - ga:goalCompletionsAll)"
+        "calculation": "(ga:goalStartsAll - ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1267,7 +1428,8 @@
         "description": "The rate at which the requested goal number was abandoned.",
         "calculation": "((ga:goalXXStarts - ga:goalXXCompletions)) / (ga:goalXXStarts)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1282,7 +1444,8 @@
         "description": "The rate at which the requested goal number was abandoned.",
         "calculation": "((ga:goalXXStarts - ga:goalXXCompletions)) / (ga:goalXXStarts)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1297,7 +1460,8 @@
         "description": "The rate at which the requested goal number was abandoned.",
         "calculation": "((ga:goalXXStarts - ga:goalXXCompletions)) / (ga:goalXXStarts)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1309,8 +1473,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Total Abandonment Rate",
-        "description": "The rate at which goals were abandoned.",
-        "calculation": "((ga:goalStartsAll - ga:goalCompletionsAll)) / (ga:goalStartsAll)"
+        "description": "Goal abandonment rate.",
+        "calculation": "((ga:goalStartsAll - ga:goalCompletionsAll)) / (ga:goalStartsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1322,8 +1487,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Browser",
-        "description": "The names of browsers used by users to your website. For example, Internet Explorer or Firefox.",
-        "allowedInSegments": "true"
+        "description": "The name of users' browsers, for example, Internet Explorer or Firefox.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1335,8 +1501,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Browser Version",
-        "description": "The browser versions used by users to your website. For example, 2.0.0.14",
-        "allowedInSegments": "true"
+        "description": "The version of users' browsers, for example, 2.0.0.14.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1348,8 +1515,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Operating System",
-        "description": "The operating system used by your users. For example, Windows, Linux , Macintosh, iPhone, iPod.",
-        "allowedInSegments": "true"
+        "description": "Users' operating system, for example, Windows, Linux, Macintosh, or iOS.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1361,8 +1529,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Operating System Version",
-        "description": "The version of the operating system used by your users, such as XP for Windows or PPC for Macintosh.",
-        "allowedInSegments": "true"
+        "description": "The version of users' operating system, i.e., XP for Windows, PPC for Macintosh.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1375,7 +1544,8 @@
         "status": "DEPRECATED",
         "uiName": "Mobile (Including Tablet)",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:deviceCategory instead (e.g., ga:deviceCategory==mobile).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1388,7 +1558,8 @@
         "status": "DEPRECATED",
         "uiName": "Tablet",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:deviceCategory instead (e.g., ga:deviceCategory==tablet).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1401,7 +1572,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Branding",
         "description": "Mobile manufacturer or branded name.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1413,8 +1585,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Mobile Device Model",
-        "description": "Mobile device model",
-        "allowedInSegments": "true"
+        "description": "Mobile device model.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1426,8 +1599,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Mobile Input Selector",
-        "description": "Selector used on the mobile device (e.g.: touchscreen, joystick, clickwheel, stylus).",
-        "allowedInSegments": "true"
+        "description": "Selector (e.g., touchscreen, joystick, clickwheel, stylus) used on the mobile device.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1440,7 +1614,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Info",
         "description": "The branding, model, and marketing name used to identify the mobile device.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1453,7 +1628,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Marketing Name",
         "description": "The marketing name used for the mobile device.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1466,7 +1642,8 @@
         "status": "PUBLIC",
         "uiName": "Device Category",
         "description": "The type of device: desktop, tablet, or mobile.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1478,8 +1655,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Continent",
-        "description": "The continents of property users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' continents, derived from users' IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1491,8 +1669,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Sub Continent",
-        "description": "The sub-continent of users, derived from IP addresses. For example, Polynesia or Northern Europe.",
-        "allowedInSegments": "true"
+        "description": "Users' sub-continent, derived from their IP addresses or Geographical IDs. For example, Polynesia or Northern Europe.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1504,8 +1683,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Country",
-        "description": "The country of users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' country, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1517,8 +1697,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Region",
-        "description": "The region of users to your property, derived from IP addresses. In the U.S., a region is a state, such as New York.",
-        "allowedInSegments": "true"
+        "description": "Users' region, derived from their IP addresses or Geographical IDs. In U.S., a region is a state, New York, for example.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1530,8 +1711,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Metro",
-        "description": "The Designated Market Area (DMA) from where traffic arrived on your property.",
-        "allowedInSegments": "true"
+        "description": "The Designated Market Area (DMA) from where traffic arrived.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1543,8 +1725,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "City",
-        "description": "The cities of property users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' city, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1556,7 +1739,8 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Latitude",
-        "description": "The approximate latitude of the user's city. Derived from IP address. Locations north of the equator are represented by positive values and locations south of the equator by negative values."
+        "description": "The approximate latitude of users' city, derived from their IP addresses or Geographical IDs. Locations north of the equator have positive latitudes and locations south of the equator have negative latitudes.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1568,7 +1752,8 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Longitude",
-        "description": "The approximate longitude of the user's city. Derived from IP address. Locations east of the meridian are represented by positive values and locations west of the meridian by negative values."
+        "description": "The approximate latitude of users' city, derived from their IP addresses or Geographical IDs. Locations north of the equator have positive latitudes and locations south of the equator have negative latitudes.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1580,8 +1765,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Network Domain",
-        "description": "The domain name of the ISPs used by users to your property. This is derived from the domain name registered to the IP address.",
-        "allowedInSegments": "true"
+        "description": "The domain name of users' ISP, derived from the domain name registered to the ISP's IP address.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1593,8 +1779,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Service Provider",
-        "description": "The name of service providers used to reach your property. For example, if most users to your website come via the major service providers for cable internet, you will see the names of those cable service providers in this element.",
-        "allowedInSegments": "true"
+        "description": "The names of the service providers used to reach the property. For example, if most users of the website come via the major cable internet service providers, its value will be these service providers' names.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1606,8 +1793,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Flash Version",
-        "description": "The versions of Flash supported by users' browsers, including minor versions.",
-        "allowedInSegments": "true"
+        "description": "The version of Flash, including minor versions, supported by users' browsers.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1619,8 +1807,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Java Support",
-        "description": "Indicates Java support for users' browsers. The possible values are Yes or No where the first letter must be capitalized.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either Yes or No, indicating whether Java is enabled in users' browsers.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1632,8 +1821,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Language",
-        "description": "The language provided by the HTTP Request for the browser. Values are given as an ISO-639 code (e.g. en-gb for British English).",
-        "allowedInSegments": "true"
+        "description": "The language, in ISO-639 code format (e.g., en-gb for British English), provided by the HTTP Request for the browser.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1645,8 +1835,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Screen Colors",
-        "description": "The color depth of users' monitors, as retrieved from the DOM of the user's browser. For example 4-bit, 8-bit, 24-bit, or undefined-bit.",
-        "allowedInSegments": "true"
+        "description": "The color depth of users' monitors, retrieved from the DOM of users' browsers. For example, 4-bit, 8-bit, 24-bit, or undefined-bit.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1658,8 +1849,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Source Property Display Name",
-        "description": "Source property display name of roll-up properties. This is valid only for roll-up properties.",
-        "allowedInSegments": "true"
+        "description": "Source property display name of roll-up properties. This is valid for only roll-up properties.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1671,8 +1863,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Source Property Tracking ID",
-        "description": "Source property tracking ID of roll-up properties. This is valid only for roll-up properties.",
-        "allowedInSegments": "true"
+        "description": "Source property tracking ID of roll-up properties. This is valid for only roll-up properties.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1684,8 +1877,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Screen Resolution",
-        "description": "The screen resolution of users' screens. For example: 1024x738.",
-        "allowedInSegments": "true"
+        "description": "Resolution of users' screens, for example, 1024x738.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1695,9 +1889,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Endorsing URL",
-        "description": "For a social data hub activity, this value represents the URL of the social activity (e.g. the Google+ post URL, the blog comment URL, etc.)"
+        "description": "For a social data hub activity, this is the URL of the social activity (e.g., the Google+ post URL, the blog comment URL, etc.).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1707,9 +1902,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Display Name",
-        "description": "For a social data hub activity, this value represents the title of the social activity posted by the social network user."
+        "description": "For a social data hub activity, this is the title of the social activity posted by the social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1719,9 +1915,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Activity Post",
-        "description": "For a social data hub activity, this value represents the content of the social activity posted by the social network user (e.g. The message content of a Google+ post)"
+        "description": "For a social data hub activity, this is the content of the social activity (e.g., the content of a message posted in Google+) posted by social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1731,9 +1928,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Activity Timestamp",
-        "description": "For a social data hub activity, this value represents when the social activity occurred on the social network."
+        "description": "For a social data hub activity, this is the time when the social activity occurred on the social network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1743,9 +1941,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social User Handle",
-        "description": "For a social data hub activity, this value represents the social network handle (e.g. name or ID) of the user who initiated the social activity."
+        "description": "For a social data hub activity, this is the social network handle (e.g., name or ID) of users who initiated the social activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1755,9 +1954,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "User Photo URL",
-        "description": "For a social data hub activity, this value represents the URL of the photo associated with the user's social network profile."
+        "description": "For a social data hub activity, this is the URL of the photo associated with users' social network profiles.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1767,9 +1967,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "User Profile URL",
-        "description": "For a social data hub activity, this value represents the URL of the associated user's social network profile."
+        "description": "For a social data hub activity, this is the URL of the associated users' social network profiles.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1779,9 +1980,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Shared URL",
-        "description": "For a social data hub activity, this value represents the URL shared by the associated social network user."
+        "description": "For a social data hub activity, this is the URL shared by the associated social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1791,9 +1993,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Tags Summary",
-        "description": "For a social data hub activity, this is a comma-separated set of tags associated with the social activity."
+        "description": "For a social data hub activity, this is a comma-separated set of tags associated with the social activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1803,9 +2006,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Originating Social Action",
-        "description": "For a social data hub activity, this value represents the type of social action associated with the activity (e.g. vote, comment, +1, etc.)."
+        "description": "For a social data hub activity, this represents the type of social action (e.g., vote, comment, +1, etc.) associated with the activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1815,9 +2019,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Network and Action",
-        "description": "For a social data hub activity, this value represents the type of social action and the social network where the activity originated."
+        "description": "For a social data hub activity, this is the type of social action and the social network where the activity originated.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1827,9 +2032,10 @@
         "type": "METRIC",
         "dataType": "INTEGER",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Data Hub Activities",
-        "description": "The count of activities where a content URL was shared / mentioned on a social data hub partner network."
+        "description": "Total number of activities where a content URL was shared or mentioned on a social data hub partner network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1842,7 +2048,8 @@
         "status": "PUBLIC",
         "uiName": "Hostname",
         "description": "The hostname from which the tracking request was made.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1854,8 +2061,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page",
-        "description": "A page on your website specified by path and/or query parameters. Use in conjunction with hostname to get the full URL of the page.",
-        "allowedInSegments": "true"
+        "description": "A page on the website specified by path and/or query parameters. Use this with hostname to get the page's full URL.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1867,7 +2075,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 1",
-        "description": "This dimension rolls up all the page paths in the first hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the first hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1879,7 +2088,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 2",
-        "description": "This dimension rolls up all the page paths in the second hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the second hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1891,7 +2101,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 3",
-        "description": "This dimension rolls up all the page paths in the third hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the third hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1903,7 +2114,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 4",
-        "description": "This dimension rolls up all the page paths into hierarchical levels. Up to 4 pagePath levels maybe specified. All additional levels in the pagePath hierarchy are also rolled up in this dimension."
+        "description": "This dimension rolls up all the page paths into hierarchical levels. Up to 4 pagePath levels maybe specified. All additional levels in the pagePath hierarchy are also rolled up in this dimension.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1915,8 +2127,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page Title",
-        "description": "The title of a page. Keep in mind that multiple pages might have the same page title.",
-        "allowedInSegments": "true"
+        "description": "The page's title. Multiple pages might have the same page title.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1928,8 +2141,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Landing Page",
-        "description": "The first page in a user's session, or landing page.",
-        "allowedInSegments": "true"
+        "description": "The first page in users' sessions, or the landing page.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1941,7 +2155,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Second Page",
-        "description": "The second page in a user's session."
+        "description": "The second page in users' sessions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1953,8 +2168,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Exit Page",
-        "description": "The last page in a user's session, or exit page.",
-        "allowedInSegments": "true"
+        "description": "The last page or exit page in users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1966,7 +2182,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Previous Page Path",
-        "description": "A page on your property that was visited before another page on the same property. Typically used with the pagePath dimension."
+        "description": "A page visited before another page on the same property, typically used with the pagePath dimension.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1976,9 +2193,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Page Tracking",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Path",
-        "description": "A page on your website that was visited after another page on your website. Typically used with the previousPagePath dimension."
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:pagePath instead.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1991,7 +2209,8 @@
         "status": "PUBLIC",
         "uiName": "Page Depth",
         "description": "The number of pages visited by users during a session. The value is a histogram that counts pageviews across a range of possible values. In this calculation, all sessions will have at least one pageview, and some percentage of sessions will have more.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2003,7 +2222,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page Value",
-        "description": "The average value of this page or set of pages. Page Value is (ga:transactionRevenue + ga:goalValueAll) / ga:uniquePageviews (for the page or set of pages)."
+        "description": "The average value of this page or set of pages, which is equal to (ga:transactionRevenue + ga:goalValueAll) / ga:uniquePageviews.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2015,8 +2235,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Entrances",
-        "description": "The number of entrances to your property measured as the first pageview in a session. Typically used with landingPagePath",
-        "allowedInSegments": "true"
+        "description": "The number of entrances to the property measured as the first pageview in a session, typically used with landingPagePath.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2029,7 +2250,8 @@
         "status": "PUBLIC",
         "uiName": "Entrances / Pageviews",
         "description": "The percentage of pageviews in which this page was the entrance.",
-        "calculation": "ga:entrances / ga:pageviews"
+        "calculation": "ga:entrances / ga:pageviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2041,8 +2263,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Pageviews",
-        "description": "The total number of pageviews for your property.",
-        "allowedInSegments": "true"
+        "description": "The total number of pageviews for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2054,8 +2277,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Pages / Session",
-        "description": "The average number of pages viewed during a session on your property. Repeated views of a single page are counted.",
-        "calculation": "ga:pageviews / ga:sessions"
+        "description": "The average number of pages viewed during a session, including repeated views of a single page.",
+        "calculation": "ga:pageviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2068,8 +2292,9 @@
         "group": "Page Tracking",
         "status": "DEPRECATED",
         "uiName": "Pages / Session",
-        "description": "The average number of pages viewed during a session on your property. Repeated views of a single page are counted.",
-        "calculation": "ga:pageviews / ga:sessions"
+        "description": "The average number of pages viewed during a session, including repeated views of a single page.",
+        "calculation": "ga:pageviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2081,9 +2306,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 1",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2095,9 +2321,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 2",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2109,9 +2336,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 3",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2123,9 +2351,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 4",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2137,9 +2366,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 5",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2151,8 +2381,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Pageviews",
-        "description": "The number of different (unique) pages within a session. This takes into account both the pagePath and pageTitle to determine uniqueness.",
-        "allowedInSegments": "true"
+        "description": "The number of unique page views. Page views in different sessions are counted as unique page views. Both the pagePath and pageTitle are used to determine page view uniqueness.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2164,8 +2395,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Time on Page",
-        "description": "How long a user spent on a particular page in seconds. Calculated by subtracting the initial view time for a particular page from the initial view time for a subsequent page. Thus, this metric does not apply to exit pages for your property.",
-        "allowedInSegments": "true"
+        "description": "Time (in seconds) users spent on a particular page, calculated by subtracting the initial view time for a particular page from the initial view time for a subsequent page. This metric does not apply to exit pages of the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2177,8 +2409,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Avg. Time on Page",
-        "description": "The average amount of time users spent viewing this page or a set of pages.",
-        "calculation": "ga:timeOnPage / (ga:pageviews - ga:exits)"
+        "description": "The average time users spent viewing this page or a set of pages.",
+        "calculation": "ga:timeOnPage / (ga:pageviews - ga:exits)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2190,8 +2423,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Exits",
-        "description": "The number of exits from your property.",
-        "allowedInSegments": "true"
+        "description": "The number of exits from the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2203,8 +2437,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "% Exit",
-        "description": "The percentage of exits from your property that occurred out of the total page views.",
-        "calculation": "ga:exits / (ga:pageviews + ga:screenviews)"
+        "description": "The percentage of exits from the property that occurred out of the total pageviews.",
+        "calculation": "ga:exits / (ga:pageviews + ga:screenviews)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2216,8 +2451,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Status",
-        "description": "A boolean to distinguish whether internal search was used in a session. Values are Visits With Site Search and Visits Without Site Search.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either Visits With Site Search or Visits Without Site Search, to distinguish whether internal search was used in a session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2229,8 +2465,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Term",
-        "description": "Search terms used by users within your property.",
-        "allowedInSegments": "true"
+        "description": "Search term used within the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2242,8 +2479,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Refined Keyword",
-        "description": "Subsequent keyword search terms or strings entered by users after a given initial string search.",
-        "allowedInSegments": "true"
+        "description": "Subsequent keyword search term or string entered by users after a given initial string search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2255,8 +2493,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Category",
-        "description": "The categories used for the internal search if you have this enabled for your profile. For example, you might have product categories such as electronics, furniture, or clothing.",
-        "allowedInSegments": "true"
+        "description": "The category used for the internal search if site search categories are enabled in the view. For example, the product category may be electronics, furniture, or clothing.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2268,7 +2507,8 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Start Page",
-        "description": "A page where the user initiated an internal search on your property."
+        "description": "The page where users initiated an internal search.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2280,7 +2520,22 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Destination Page",
-        "description": "The page the user immediately visited after performing an internal search on your site. (Usually the search results page)."
+        "description": "The page users immediately visited after performing an internal search on the site. This is usually the search results page.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:searchAfterDestinationPage",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Internal Search",
+        "status": "PUBLIC",
+        "uiName": "Search Destination Page",
+        "description": "The page that users visited after performing an internal search on the site.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2292,7 +2547,8 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Results Pageviews",
-        "description": "The number of times a search result page was viewed after performing a search."
+        "description": "The number of times a search result page was viewed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2304,8 +2560,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Total Unique Searches",
-        "description": "The total number of unique keywords from internal searches within a session. For example if \"shoes\" was searched for 3 times in a session, it will be only counted once.",
-        "allowedInSegments": "true"
+        "description": "Total number of unique keywords from internal searches within a session. For example, if \"shoes\" was searched for 3 times in a session, it would be counted only once.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2317,8 +2574,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Results Pageviews / Search",
-        "description": "The average number of times people viewed a search results page after performing a search.",
-        "calculation": "ga:searchResultViews / ga:searchUniques"
+        "description": "The average number of times people viewed a page as a result of a search.",
+        "calculation": "ga:searchResultViews / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2330,8 +2588,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Sessions with Search",
-        "description": "The total number of sessions that included an internal search",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions that included an internal search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2344,8 +2603,9 @@
         "group": "Internal Search",
         "status": "DEPRECATED",
         "uiName": "Sessions with Search",
-        "description": "The total number of sessions that included an internal search",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions that included an internal search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2358,7 +2618,8 @@
         "status": "PUBLIC",
         "uiName": "% Sessions with Search",
         "description": "The percentage of sessions with search.",
-        "calculation": "ga:searchSessions / ga:sessions"
+        "calculation": "ga:searchSessions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2372,7 +2633,8 @@
         "status": "DEPRECATED",
         "uiName": "% Sessions with Search",
         "description": "The percentage of sessions with search.",
-        "calculation": "ga:searchSessions / ga:sessions"
+        "calculation": "ga:searchSessions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2384,8 +2646,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Depth",
-        "description": "The average number of subsequent page views made on your property after a use of your internal search feature.",
-        "allowedInSegments": "true"
+        "description": "The total number of subsequent page views made after a use of the site's internal search feature.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2397,8 +2660,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Average Search Depth",
-        "description": "The average number of pages people viewed after performing a search on your property.",
-        "calculation": "ga:searchDepth / ga:searchUniques"
+        "description": "The average number of pages people viewed after performing a search.",
+        "calculation": "ga:searchDepth / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2410,8 +2674,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Refinements",
-        "description": "The total number of times a refinement (transition) occurs between internal search keywords within a session. For example if the sequence of keywords is: \"shoes\", \"shoes\", \"pants\", \"pants\", this metric will be one because the transition between \"shoes\" and \"pants\" is different.",
-        "allowedInSegments": "true"
+        "description": "The total number of times a refinement (transition) occurs between internal keywords search within a session. For example, if the sequence of keywords is \"shoes\", \"shoes\", \"pants\", \"pants\", this metric will be one because the transition between \"shoes\" and \"pants\" is different.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2423,8 +2688,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "% Search Refinements",
-        "description": "The percentage of number of times a refinement (i.e., transition) occurs between internal search keywords within a session.",
-        "calculation": "ga:searchRefinements / ga:searchResultViews"
+        "description": "The percentage of the number of times a refinement (i.e., transition) occurs between internal keywords search within a session.",
+        "calculation": "ga:searchRefinements / ga:searchResultViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2436,8 +2702,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Time after Search",
-        "description": "The session duration on your property where a use of your internal search feature occurred.",
-        "allowedInSegments": "true"
+        "description": "The session duration when the site's internal search feature is used.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2449,8 +2716,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Time after Search",
-        "description": "The average amount of time people spent on your property after searching.",
-        "calculation": "ga:searchDuration / ga:searchUniques"
+        "description": "The average time (in seconds) users, after searching, spent on the property.",
+        "calculation": "ga:searchDuration / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2462,8 +2730,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Exits",
-        "description": "The number of exits on your site that occurred following a search result from your internal search feature.",
-        "allowedInSegments": "true"
+        "description": "The number of exits on the site that occurred following a search result from the site's internal search feature.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2475,8 +2744,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "% Search Exits",
-        "description": "The percentage of searches that resulted in an immediate exit from your property.",
-        "calculation": "ga:searchExits / ga:searchUniques"
+        "description": "The percentage of searches that resulted in an immediate exit from the property.",
+        "calculation": "ga:searchExits / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2491,7 +2761,8 @@
         "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:searchUniques",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2506,7 +2777,8 @@
         "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:searchUniques",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2521,7 +2793,8 @@
         "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:searchUniques",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2533,8 +2806,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Goal Conversion Rate",
-        "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to at least one of your goals.",
-        "calculation": "ga:goalCompletionsAll / ga:searchUniques"
+        "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to at least one of the goals.",
+        "calculation": "ga:goalCompletionsAll / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2546,8 +2820,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Per Search Goal Value",
-        "description": "The average goal value of a search on your property.",
-        "calculation": "ga:goalValueAll / ga:searchUniques"
+        "description": "The average goal value of a search.",
+        "calculation": "ga:goalValueAll / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2559,7 +2834,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Load Time (ms)",
-        "description": "Total Page Load Time is the amount of time (in milliseconds) it takes for pages from the sample set to load, from initiation of the pageview (e.g. click on a page link) to load completion in the browser."
+        "description": "Total time (in milliseconds), from pageview initiation (e.g., a click on a page link) to page load completion in the browser, the pages in the sample set take to load.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2571,7 +2847,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Load Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the average page load time."
+        "description": "The sample set (or count) of pageviews used to calculate the average page load time.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2583,8 +2860,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Page Load Time (sec)",
-        "description": "The average amount of time (in seconds) it takes for pages from the sample set to load, from initiation of the pageview (e.g. click on a page link) to load completion in the browser.",
-        "calculation": "(ga:pageLoadTime / ga:pageLoadSample / 1000)"
+        "description": "The average time (in seconds) pages from the sample set take to load, from initiation of the pageview (e.g., a click on a page link) to load completion in the browser.",
+        "calculation": "(ga:pageLoadTime / ga:pageLoadSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2596,7 +2874,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Domain Lookup Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in DNS lookup for this page among all samples."
+        "description": "The total time (in milliseconds) all samples spent in DNS lookup for this page.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2608,8 +2887,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Domain Lookup Time (sec)",
-        "description": "The average amount of time (in seconds) spent in DNS lookup for this page.",
-        "calculation": "(ga:domainLookupTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in DNS lookup for this page.",
+        "calculation": "(ga:domainLookupTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2621,7 +2901,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Download Time (ms)",
-        "description": "The total amount of time (in milliseconds) to download this page among all samples."
+        "description": "The total time (in milliseconds) to download this page among all samples.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2633,8 +2914,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Page Download Time (sec)",
-        "description": "The average amount of time (in seconds) to download this page.",
-        "calculation": "(ga:pageDownloadTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) to download this page.",
+        "calculation": "(ga:pageDownloadTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2646,7 +2928,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Redirection Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in redirects before fetching this page among all samples. If there are no redirects, the value for this metric is expected to be 0."
+        "description": "The total time (in milliseconds) all samples spent in redirects before fetching this page. If there are no redirects, this is 0.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2658,8 +2941,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Redirection Time (sec)",
-        "description": "The average amount of time (in seconds) spent in redirects before fetching this page. If there are no redirects, the value for this metric is expected to be 0.",
-        "calculation": "(ga:redirectionTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in redirects before fetching this page. If there are no redirects, this is 0.",
+        "calculation": "(ga:redirectionTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2671,7 +2955,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Server Connection Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in establishing TCP connection for this page among all samples."
+        "description": "Total time (in milliseconds) all samples spent in establishing a TCP connection to this page.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2683,8 +2968,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Server Connection Time (sec)",
-        "description": "The average amount of time (in seconds) spent in establishing TCP connection for this page.",
-        "calculation": "(ga:serverConnectionTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in establishing a TCP connection to this page.",
+        "calculation": "(ga:serverConnectionTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2696,7 +2982,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Server Response Time (ms)",
-        "description": "The total amount of time (in milliseconds) your server takes to respond to a user request among all samples, including the network time from user's location to your server."
+        "description": "The total time (in milliseconds) the site's server takes to respond to users' requests among all samples; this includes the network time from users' locations to the server.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2708,8 +2995,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Server Response Time (sec)",
-        "description": "The average amount of time (in seconds) your server takes to respond to a user request, including the network time from user's location to your server.",
-        "calculation": "(ga:serverResponseTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) the site's server takes to respond to users' requests; this includes the network time from users' locations to the server.",
+        "calculation": "(ga:serverResponseTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2721,7 +3009,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Speed Metrics Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the averages for site speed metrics. This metric is used in all site speed average calculations including avgDomainLookupTime, avgPageDownloadTime, avgRedirectionTime, avgServerConnectionTime, and avgServerResponseTime."
+        "description": "The sample set (or count) of pageviews used to calculate the averages of site speed metrics. This metric is used in all site speed average calculations, including avgDomainLookupTime, avgPageDownloadTime, avgRedirectionTime, avgServerConnectionTime, and avgServerResponseTime.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2733,7 +3022,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Document Interactive Time (ms)",
-        "description": "The time the browser takes (in milliseconds) to parse the document (DOMInteractive), including the network time from the user's location to your server. At this time, the user can interact with the Document Object Model even though it is not fully loaded."
+        "description": "The time (in milliseconds), including the network time from users' locations to the site's server, the browser takes to parse the document (DOMInteractive). At this time, users can interact with the Document Object Model even though it is not fully loaded.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2745,8 +3035,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Document Interactive Time (sec)",
-        "description": "The average time (in seconds) it takes the browser to parse the document and execute deferred and parser-inserted scripts including the network time from the user's location to your server.",
-        "calculation": "(ga:domInteractiveTime / ga:domLatencyMetricsSample / 1000)"
+        "description": "The average time (in seconds), including the network time from users' locations to the site's server, the browser takes to parse the document and execute deferred and parser-inserted scripts.",
+        "calculation": "(ga:domInteractiveTime / ga:domLatencyMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2758,7 +3049,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Document Content Loaded Time (ms)",
-        "description": "The time the browser takes (in milliseconds) to parse the document and execute deferred and parser-inserted scripts (DOMContentLoaded), including the network time from the user's location to your server. Parsing of the document is finished, the Document Object Model is ready, but referenced style sheets, images, and subframes may not be finished loading. This event is often the starting point for javascript framework execution, e.g., JQuery's onready() callback, etc."
+        "description": "The time (in milliseconds), including the network time from users' locations to the site's server, the browser takes to parse the document and execute deferred and parser-inserted scripts (DOMContentLoaded). When parsing of the document is finished, the Document Object Model (DOM) is ready, but the referenced style sheets, images, and subframes may not be finished loading. This is often the starting point of Javascript framework execution, e.g., JQuery's onready() callback.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2770,8 +3062,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Document Content Loaded Time (sec)",
-        "description": "The average time (in seconds) it takes the browser to parse the document.",
-        "calculation": "(ga:domContentLoadedTime / ga:domLatencyMetricsSample / 1000)"
+        "description": "The average time (in seconds) the browser takes to parse the document.",
+        "calculation": "(ga:domContentLoadedTime / ga:domLatencyMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2783,7 +3076,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "DOM Latency Metrics Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the averages for site speed DOM metrics. This metric is used in the avgDomContentLoadedTime and avgDomInteractiveTime calculations."
+        "description": "Sample set (or count) of pageviews used to calculate the averages for site speed DOM metrics. This metric is used to calculate ga:avgDomContentLoadedTime and ga:avgDomInteractiveTime.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2795,8 +3089,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Installer ID",
-        "description": "ID of the installer (e.g., Google Play Store) from which the app was downloaded. By default, the app installer id is set based on the PackageManager#getInstallerPackageName method.",
-        "allowedInSegments": "true"
+        "description": "The ID of the app installer (e.g., Google Play Store) from which the app was downloaded. By default, the app installer ID is set by the PackageManager#getInstallerPackageName method.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2808,8 +3103,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Version",
-        "description": "The version of the application.",
-        "allowedInSegments": "true"
+        "description": "The application version.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2821,8 +3117,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Name",
-        "description": "The name of the application.",
-        "allowedInSegments": "true"
+        "description": "The application name.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2834,8 +3131,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App ID",
-        "description": "The ID of the application.",
-        "allowedInSegments": "true"
+        "description": "The application ID.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2848,7 +3146,8 @@
         "status": "PUBLIC",
         "uiName": "Screen Name",
         "description": "The name of the screen.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2860,8 +3159,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Screen Depth",
-        "description": "The number of screenviews per session reported as a string. Can be useful for historgrams.",
-        "allowedInSegments": "true"
+        "description": "The number of screenviews (reported as a string) per session, useful for historgrams.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2873,8 +3173,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Landing Screen",
-        "description": "The name of the first screen viewed.",
-        "allowedInSegments": "true"
+        "description": "The name of the first viewed screen.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2886,8 +3187,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Exit Screen",
-        "description": "The name of the screen when the user exited the application.",
-        "allowedInSegments": "true"
+        "description": "The name of the screen where users exited the application.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2900,7 +3202,8 @@
         "status": "PUBLIC",
         "uiName": "Screen Views",
         "description": "The total number of screenviews.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2914,7 +3217,8 @@
         "status": "DEPRECATED",
         "uiName": "Screen Views",
         "description": "The total number of screenviews.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2926,8 +3230,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Screen Views",
-        "description": "The number of different (unique) screenviews within a session.",
-        "allowedInSegments": "true"
+        "description": "The number of unique screen views. Screen views in different sessions are counted as separate screen views.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2940,8 +3245,9 @@
         "group": "App Tracking",
         "status": "DEPRECATED",
         "uiName": "Unique Screen Views",
-        "description": "The number of different (unique) screenviews within a session.",
-        "allowedInSegments": "true"
+        "description": "The number of unique screen views. Screen views in different sessions are counted as separate screen views.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2954,7 +3260,8 @@
         "status": "PUBLIC",
         "uiName": "Screens / Session",
         "description": "The average number of screenviews per session.",
-        "calculation": "ga:screenviews / ga:sessions"
+        "calculation": "ga:screenviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2968,7 +3275,8 @@
         "status": "DEPRECATED",
         "uiName": "Screens / Session",
         "description": "The average number of screenviews per session.",
-        "calculation": "ga:screenviews / ga:sessions"
+        "calculation": "ga:screenviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2981,7 +3289,8 @@
         "status": "PUBLIC",
         "uiName": "Time on Screen",
         "description": "The time spent viewing the current screen.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2993,7 +3302,8 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Avg. Time on Screen",
-        "description": "The average amount of time users spent on a screen in seconds."
+        "description": "Average time (in seconds) users spent on a screen.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3005,8 +3315,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Category",
-        "description": "The category of the event.",
-        "allowedInSegments": "true"
+        "description": "The event category.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3018,8 +3329,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Action",
-        "description": "The action of the event.",
-        "allowedInSegments": "true"
+        "description": "Event action.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3031,8 +3343,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Label",
-        "description": "The label of the event.",
-        "allowedInSegments": "true"
+        "description": "Event label.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3045,7 +3358,8 @@
         "status": "PUBLIC",
         "uiName": "Total Events",
         "description": "The total number of events for the profile, across all categories.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3057,7 +3371,8 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Events",
-        "description": "The total number of unique events for the profile, across all categories."
+        "description": "The number of unique events. Events in different sessions are counted as separate events.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3069,8 +3384,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Value",
-        "description": "The total value of events for the profile.",
-        "allowedInSegments": "true"
+        "description": "Total value of events for the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3083,7 +3399,8 @@
         "status": "PUBLIC",
         "uiName": "Avg. Value",
         "description": "The average value of an event.",
-        "calculation": "ga:eventValue / ga:totalEvents"
+        "calculation": "ga:eventValue / ga:totalEvents",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3096,7 +3413,8 @@
         "status": "PUBLIC",
         "uiName": "Sessions with Event",
         "description": "The total number of sessions with events.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3110,7 +3428,8 @@
         "status": "DEPRECATED",
         "uiName": "Sessions with Event",
         "description": "The total number of sessions with events.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3123,7 +3442,8 @@
         "status": "PUBLIC",
         "uiName": "Events / Session with Event",
         "description": "The average number of events per session with event.",
-        "calculation": "ga:totalEvents / ga:sessionsWithEvent"
+        "calculation": "ga:totalEvents / ga:sessionsWithEvent",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3137,7 +3457,8 @@
         "status": "DEPRECATED",
         "uiName": "Events / Session with Event",
         "description": "The average number of events per session with event.",
-        "calculation": "ga:totalEvents / ga:sessionsWithEvent"
+        "calculation": "ga:totalEvents / ga:sessionsWithEvent",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3149,8 +3470,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Transaction ID",
-        "description": "The transaction ID for the shopping cart purchase as supplied by your ecommerce tracking method.",
-        "allowedInSegments": "true"
+        "description": "The transaction ID, supplied by the ecommerce tracking method, for the purchase in the shopping cart.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3162,8 +3484,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Affiliation",
-        "description": "Typically used to designate a supplying company or brick and mortar location; product affiliation.",
-        "allowedInSegments": "true"
+        "description": "A product affiliation to designate a supplying company or brick and mortar location.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3176,7 +3499,8 @@
         "status": "PUBLIC",
         "uiName": "Sessions to Transaction",
         "description": "The number of sessions between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3190,7 +3514,8 @@
         "status": "DEPRECATED",
         "uiName": "Sessions to Transaction",
         "description": "The number of sessions between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3203,7 +3528,8 @@
         "status": "PUBLIC",
         "uiName": "Days to Transaction",
         "description": "The number of days between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3215,8 +3541,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product SKU",
-        "description": "The product sku for purchased items as you have defined them in your ecommerce tracking application.",
-        "allowedInSegments": "true"
+        "description": "The product SKU, defined in the ecommerce tracking application, for purchased items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3228,8 +3555,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product",
-        "description": "The product name for purchased items as supplied by your ecommerce tracking application.",
-        "allowedInSegments": "true"
+        "description": "The product name, supplied by the ecommerce tracking application, for purchased items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3241,8 +3569,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Category",
-        "description": "Any product variations (size, color) for purchased items as supplied by your ecommerce application. Not compatible with Enhanced Ecommerce.",
-        "allowedInSegments": "true"
+        "description": "Any product variation (size, color) supplied by the ecommerce application for purchased items, not compatible with Enhanced Ecommerce.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3254,7 +3583,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Currency Code",
-        "description": "The local currency code of the transaction based on ISO 4217 standard."
+        "description": "The local currency code (based on ISO 4217 standard) of the transaction.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3267,7 +3597,8 @@
         "status": "PUBLIC",
         "uiName": "Transactions",
         "description": "The total number of transactions.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3279,8 +3610,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Ecommerce Conversion Rate",
-        "description": "The average number of transactions for a session on your property.",
-        "calculation": "ga:transactions / ga:sessions"
+        "description": "The average number of transactions in a session.",
+        "calculation": "ga:transactions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3293,8 +3625,9 @@
         "group": "Ecommerce",
         "status": "DEPRECATED",
         "uiName": "Ecommerce Conversion Rate",
-        "description": "The average number of transactions for a session on your property.",
-        "calculation": "ga:transactions / ga:sessions"
+        "description": "The average number of transactions in a session.",
+        "calculation": "ga:transactions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3306,8 +3639,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Revenue",
-        "description": "The total sale revenue provided in the transaction excluding shipping and tax.",
-        "allowedInSegments": "true"
+        "description": "The total sale revenue (excluding shipping and tax) of the transaction.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3319,8 +3653,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Average Order Value",
-        "description": "The average revenue for an e-commerce transaction.",
-        "calculation": "ga:transactionRevenue / ga:transactions"
+        "description": "The average revenue of an ecommerce transaction.",
+        "calculation": "ga:transactionRevenue / ga:transactions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3332,8 +3667,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Per Session Value",
-        "description": "Average transaction revenue for a session on your property.",
-        "calculation": "ga:transactionRevenue / ga:sessions"
+        "description": "Average transaction revenue for a session.",
+        "calculation": "ga:transactionRevenue / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3346,8 +3682,9 @@
         "group": "Ecommerce",
         "status": "DEPRECATED",
         "uiName": "Per Session Value",
-        "description": "Average transaction revenue for a session on your property.",
-        "calculation": "ga:transactionRevenue / ga:sessions"
+        "description": "Average transaction revenue for a session.",
+        "calculation": "ga:transactionRevenue / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3360,7 +3697,8 @@
         "status": "PUBLIC",
         "uiName": "Shipping",
         "description": "The total cost of shipping.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3372,8 +3710,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Tax",
-        "description": "The total amount of tax.",
-        "allowedInSegments": "true"
+        "description": "Total tax for the transaction.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3385,8 +3724,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Total Value",
-        "description": "Total value for your property (including total revenue and total goal value).",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll)"
+        "description": "Total value for the property (including total revenue and total goal value).",
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3398,8 +3738,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Quantity",
-        "description": "The total number of items purchased. For example, if users purchase 2 frisbees and 5 tennis balls, 7 items have been purchased.",
-        "allowedInSegments": "true"
+        "description": "Total number of items purchased. For example, if users purchase 2 frisbees and 5 tennis balls, this will be 7.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3411,8 +3752,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Unique Purchases",
-        "description": "The number of product sets purchased. For example, if users purchase 2 frisbees and 5 tennis balls from your site, 2 unique products have been purchased.",
-        "allowedInSegments": "true"
+        "description": "The number of product sets purchased. For example, if users purchase 2 frisbees and 5 tennis balls from the site, this will be 2.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3425,7 +3767,8 @@
         "status": "PUBLIC",
         "uiName": "Average Price",
         "description": "The average revenue per item.",
-        "calculation": "ga:itemRevenue / ga:itemQuantity"
+        "calculation": "ga:itemRevenue / ga:itemQuantity",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3437,8 +3780,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Revenue",
-        "description": "The total revenue from purchased product items on your property.",
-        "allowedInSegments": "true"
+        "description": "The total revenue from purchased product items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3451,7 +3795,8 @@
         "status": "PUBLIC",
         "uiName": "Average QTY",
         "description": "The average quantity of this item (or group of items) sold per purchase.",
-        "calculation": "ga:itemQuantity / ga:uniquePurchases"
+        "calculation": "ga:itemQuantity / ga:uniquePurchases",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3463,7 +3808,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Revenue",
-        "description": "Transaction revenue in local currency."
+        "description": "Transaction revenue in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3475,7 +3821,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Shipping",
-        "description": "Transaction shipping cost in local currency."
+        "description": "Transaction shipping cost in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3487,7 +3834,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Tax",
-        "description": "Transaction tax in local currency."
+        "description": "Transaction tax in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3500,7 +3848,8 @@
         "status": "PUBLIC",
         "uiName": "Local Product Revenue",
         "description": "Product revenue in local currency.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3511,8 +3860,9 @@
         "dataType": "STRING",
         "group": "Social Interactions",
         "status": "PUBLIC",
-        "uiName": "Social Source",
-        "description": "For social interactions, a value representing the social network being tracked."
+        "uiName": "Social Network",
+        "description": "For social interactions, this represents the social network being tracked.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3524,7 +3874,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Action",
-        "description": "For social interactions, a value representing the social action being tracked (e.g. +1, bookmark)"
+        "description": "For social interactions, this is the social action (e.g., +1, bookmark) being tracked.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3535,8 +3886,9 @@
         "dataType": "STRING",
         "group": "Social Interactions",
         "status": "PUBLIC",
-        "uiName": "Social Source and Action",
-        "description": "For social interactions, a value representing the concatenation of the socialInteractionNetwork and socialInteractionAction action being tracked at this hit level (e.g. Google: +1)"
+        "uiName": "Social Network and Action",
+        "description": "For social interactions, this is the concatenation of the socialInteractionNetwork and socialInteractionAction action (e.g., Google: +1) being tracked at this hit level.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3548,7 +3900,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Entity",
-        "description": "For social interactions, a value representing the URL (or resource) which receives the social network action."
+        "description": "For social interactions, this is the URL (or resource) which receives the social network action.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3560,7 +3913,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Type",
-        "description": "Engagement type. Possible values are \"Socially Engaged\" or \"Not Socially Engaged\"."
+        "description": "Engagement type, either \"Socially Engaged\" or \"Not Socially Engaged\".",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3572,7 +3926,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Actions",
-        "description": "The total number of social interactions on your property."
+        "description": "The total number of social interactions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3584,7 +3939,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Unique Social Actions",
-        "description": "The number of sessions during which the specified social action(s) occurred at least once. This is based on the the unique combination of socialInteractionNetwork, socialInteractionAction, and socialInteractionTarget."
+        "description": "The number of sessions during which the specified social action(s) occurred at least once. This is based on the the unique combination of socialInteractionNetwork, socialInteractionAction, and socialInteractionTarget.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3596,8 +3952,9 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Actions Per Social Session",
-        "description": "The number of social interactions per session on your property.",
-        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions"
+        "description": "The number of social interactions per session.",
+        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3610,8 +3967,9 @@
         "group": "Social Interactions",
         "status": "DEPRECATED",
         "uiName": "Actions Per Social Session",
-        "description": "The number of social interactions per session on your property.",
-        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions"
+        "description": "The number of social interactions per session.",
+        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3623,8 +3981,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Timing Category",
-        "description": "A string for categorizing all user timing variables into logical groups for easier reporting purposes.",
-        "allowedInSegments": "true"
+        "description": "For easier reporting purposes, this is used to categorize all user timing variables into logical groups.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3637,7 +3996,8 @@
         "status": "PUBLIC",
         "uiName": "Timing Label",
         "description": "The name of the resource's action being tracked.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3649,8 +4009,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Timing Variable",
-        "description": "A value that can be used to add flexibility in visualizing user timings in the reports.",
-        "allowedInSegments": "true"
+        "description": "Used to add flexibility to visualize user timings in the reports.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3662,7 +4023,8 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "User Timing (ms)",
-        "description": "The total number of milliseconds for a user timing."
+        "description": "Total number of milliseconds for user timing.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3674,7 +4036,8 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "User Timing Sample",
-        "description": "The number of hits that were sent for a particular userTimingCategory, userTimingLabel, and userTimingVariable."
+        "description": "The number of hits sent for a particular userTimingCategory, userTimingLabel, or userTimingVariable.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3686,8 +4049,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Avg. User Timing (sec)",
-        "description": "The average amount of elapsed time.",
-        "calculation": "(ga:userTimingValue / ga:userTimingSample / 1000)"
+        "description": "The average elapsed time.",
+        "calculation": "(ga:userTimingValue / ga:userTimingSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3700,7 +4064,8 @@
         "status": "PUBLIC",
         "uiName": "Exception Description",
         "description": "The description for the exception.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3712,8 +4077,9 @@
         "group": "Exceptions",
         "status": "PUBLIC",
         "uiName": "Exceptions",
-        "description": "The number of exceptions that were sent to Google Analytics.",
-        "allowedInSegments": "true"
+        "description": "The number of exceptions sent to Google Analytics.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3726,7 +4092,8 @@
         "status": "PUBLIC",
         "uiName": "Exceptions / Screen",
         "description": "The number of exceptions thrown divided by the number of screenviews.",
-        "calculation": "ga:exceptions / ga:screenviews"
+        "calculation": "ga:exceptions / ga:screenviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3739,7 +4106,8 @@
         "status": "PUBLIC",
         "uiName": "Crashes",
         "description": "The number of exceptions where isFatal is set to true.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3752,7 +4120,8 @@
         "status": "PUBLIC",
         "uiName": "Crashes / Screen",
         "description": "The number of fatal exceptions thrown divided by the number of screenviews.",
-        "calculation": "ga:fatalExceptions / ga:screenviews"
+        "calculation": "ga:fatalExceptions / ga:screenviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3764,8 +4133,9 @@
         "group": "Content Experiments",
         "status": "PUBLIC",
         "uiName": "Experiment ID",
-        "description": "The user-scoped id of the content experiment that the user was exposed to when the metrics were reported.",
-        "allowedInSegments": "true"
+        "description": "The user-scoped ID of the content experiment that users were exposed to when the metrics were reported.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3776,9 +4146,10 @@
         "dataType": "STRING",
         "group": "Content Experiments",
         "status": "PUBLIC",
-        "uiName": "Variation",
-        "description": "The user-scoped id of the particular variation that the user was exposed to during a content experiment.",
-        "allowedInSegments": "true"
+        "uiName": "Variant",
+        "description": "The user-scoped ID of the particular variant that users were exposed to during a content experiment.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3790,12 +4161,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Logged  In (Custom Dimension 1)",
-        "description": "The name of the requested custom dimension, where XX refers the number/index of the custom dimension.",
+        "description": "The value of the requested custom dimension, where XX refers to the number or index of the custom dimension.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3807,12 +4179,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Breakpoint (Custom Dimension 2)",
-        "description": "The name of the requested custom dimension, where XX refers the number/index of the custom dimension.",
+        "description": "The value of the requested custom dimension, where XX refers to the number or index of the custom dimension.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3824,12 +4197,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Random (Custom Dimension 3)",
-        "description": "The name of the requested custom dimension, where XX refers the number/index of the custom dimension.",
+        "description": "The value of the requested custom dimension, where XX refers to the number or index of the custom dimension.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3846,7 +4220,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3863,7 +4238,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3880,7 +4256,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3897,7 +4274,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3914,7 +4292,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3931,7 +4310,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3948,7 +4328,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3965,7 +4346,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3982,7 +4364,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3999,7 +4382,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4016,7 +4400,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4033,7 +4418,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4050,7 +4436,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4067,7 +4454,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4084,7 +4472,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4101,7 +4490,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4118,7 +4508,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4135,7 +4526,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4152,7 +4544,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4169,7 +4562,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4186,7 +4580,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4203,7 +4598,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4220,7 +4616,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4237,7 +4634,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4254,7 +4652,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4271,7 +4670,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4288,7 +4688,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4305,7 +4706,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4322,7 +4724,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4339,7 +4742,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4356,7 +4760,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4373,7 +4778,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4390,7 +4796,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4407,7 +4814,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4424,7 +4832,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4441,7 +4850,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4458,7 +4868,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4475,7 +4886,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4492,7 +4904,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4509,7 +4922,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4526,7 +4940,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4543,7 +4958,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4560,7 +4976,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4577,7 +4994,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4594,7 +5012,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4611,7 +5030,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4628,7 +5048,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4645,7 +5066,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4662,7 +5084,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4679,7 +5102,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4691,12 +5115,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Queries  (success) (Custom Metric 1)",
-        "description": "The name of the requested custom metric, where XX refers the number/index of the custom metric.",
+        "description": "The value of the requested custom metric, where XX refers to the number or index of the custom metric. Note that the data type of ga:metricXX can be INTEGER, CURRENCY, or TIME.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4708,12 +5133,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Queries  (error) (Custom Metric 2)",
-        "description": "The name of the requested custom metric, where XX refers the number/index of the custom metric.",
+        "description": "The value of the requested custom metric, where XX refers to the number or index of the custom metric. Note that the data type of ga:metricXX can be INTEGER, CURRENCY, or TIME.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4725,12 +5151,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Monies (Custom Metric 3)",
-        "description": "The name of the requested custom metric, where XX refers the number/index of the custom metric.",
+        "description": "The value of the requested custom metric, where XX refers to the number or index of the custom metric. Note that the data type of ga:metricXX can be INTEGER, CURRENCY, or TIME.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4747,7 +5174,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4764,7 +5192,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4781,7 +5210,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4798,7 +5228,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4815,7 +5246,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4832,7 +5264,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4849,7 +5282,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4866,7 +5300,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4883,7 +5318,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4900,7 +5336,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4917,7 +5354,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4934,7 +5372,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4951,7 +5390,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4968,7 +5408,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4985,7 +5426,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5002,7 +5444,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5019,7 +5462,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5036,7 +5480,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5053,7 +5498,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5070,7 +5516,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5087,7 +5534,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5104,7 +5552,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5121,7 +5570,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5138,7 +5588,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5155,7 +5606,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5172,7 +5624,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5189,7 +5642,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5206,7 +5660,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5223,7 +5678,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5240,7 +5696,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5257,7 +5714,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5274,7 +5732,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5291,7 +5750,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5308,7 +5768,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5325,7 +5786,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5342,7 +5804,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5359,7 +5822,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5376,7 +5840,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5393,7 +5858,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5410,7 +5876,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5427,7 +5894,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5444,7 +5912,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5461,7 +5930,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5478,7 +5948,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5495,7 +5966,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5512,7 +5984,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5529,7 +6002,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5546,7 +6020,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5563,7 +6038,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5580,7 +6056,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5592,7 +6069,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Date",
-        "description": "The date of the session formatted as YYYYMMDD."
+        "description": "The date of the session formatted as YYYYMMDD.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5604,7 +6082,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Year",
-        "description": "The year of the session. A four-digit year from 2005 to the current year."
+        "description": "The year of the session, a four-digit year from 2005 to the current year.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5616,7 +6095,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month of the year",
-        "description": "The month of the session. A two digit integer from 01 to 12."
+        "description": "Month of the session, a two digit integer from 01 to 12.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5628,7 +6108,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week of the Year",
-        "description": "The week of the session. A two-digit number from 01 to 53. Each week starts on Sunday."
+        "description": "The week of the session, a two-digit number from 01 to 53. Each week starts on Sunday.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5640,7 +6121,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of the month",
-        "description": "The day of the month. A two-digit number from 01 to 31."
+        "description": "The day of the month, a two-digit number from 01 to 31.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5652,8 +6134,9 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour",
-        "description": "A two-digit hour of the day ranging from 00-23 in the timezone configured for the account. This value is also corrected for daylight savings time, adhering to all local rules for daylight savings time. If your timezone follows daylight savings time, there will be an apparent bump in the number of sessions during the change-over hour (e.g. between 1:00 and 2:00) for the day per year when that hour repeats. A corresponding hour with zero sessions will occur at the opposite changeover. (Google Analytics does not track user time more precisely than hours.)",
-        "allowedInSegments": "true"
+        "description": "A two-digit hour of the day ranging from 00-23 in the timezone configured for the account. This value is also corrected for daylight savings time. If the timezone follows daylight savings time, there will be an apparent bump in the number of sessions during the changeover hour (e.g., between 1:00 and 2:00) for the day per year when that hour repeats. A corresponding hour with zero sessions will occur at the opposite changeover. (Google Analytics does not track user time more precisely than hours.)",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5665,8 +6148,9 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Minute",
-        "description": "Returns the minute in the hour. The possible values are between 00 and 59.",
-        "allowedInSegments": "true"
+        "description": "Returns the minutes, between 00 and 59, in the hour.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5678,7 +6162,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month Index",
-        "description": "Index for each month in the specified date range. Index for the first month in the date range is 0, 1 for the second month, and so on. The index corresponds to month entries."
+        "description": "The index for a month in the specified date range. In the date range, the index for the first month is 0, for the second month 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5690,7 +6175,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week Index",
-        "description": "Index for each week in the specified date range. Index for the first week in the date range is 0, 1 for the second week, and so on. The index corresponds to week entries."
+        "description": "The index for each week in the specified date range. The index for the first week in the date range is 0, for the second week 1, and so on. The index corresponds to week entries.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5702,7 +6188,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day Index",
-        "description": "Index for each day in the specified date range. Index for the first day (i.e., start-date) in the date range is 0, 1 for the second day, and so on."
+        "description": "The index for each day in the specified date range. The index for the first day (i.e., start-date) in the date range is 0, for the second day 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5714,7 +6201,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Minute Index",
-        "description": "Index for each minute in the specified date range. Index for the first minute of first day (i.e., start-date) in the date range is 0, 1 for the next minute, and so on."
+        "description": "The index for each minute in the specified date range. The index for the first minute of the first day (i.e., start-date) in the date range is 0, for the next minute 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5726,7 +6214,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of Week",
-        "description": "The day of the week. A one-digit number from 0 (Sunday) to 6 (Saturday)."
+        "description": "Day of the week, a one-digit number from 0 (Sunday) to 6 (Saturday).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5738,7 +6227,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of Week Name",
-        "description": "The name of the day of the week (in English)."
+        "description": "Name (in English) of the day of the week.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5750,7 +6240,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour of Day",
-        "description": "Combined values of ga:date and ga:hour."
+        "description": "Combined values of ga:date and ga:hour.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5762,7 +6253,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month of Year",
-        "description": "Combined values of ga:year and ga:month."
+        "description": "Combined values of ga:year and ga:month.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5774,7 +6266,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week of Year",
-        "description": "Combined values of ga:year and ga:week."
+        "description": "Combined values of ga:year and ga:week.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5786,7 +6279,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Week of the Year",
-        "description": "The ISO week number, where each week starts with a Monday. Details: http://en.wikipedia.org/wiki/ISO_week_date. ga:isoWeek should only be used with ga:isoYear since ga:year represents gregorian calendar."
+        "description": "ISO week number, where each week starts on Monday. For details, see http://en.wikipedia.org/wiki/ISO_week_date. ga:isoWeek should only be used with ga:isoYear because ga:year represents Gregorian calendar.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5798,7 +6292,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Year",
-        "description": "The ISO year of the session. Details: http://en.wikipedia.org/wiki/ISO_week_date. ga:isoYear should only be used with ga:isoWeek since ga:week represents gregorian calendar."
+        "description": "The ISO year of the session. For details, see http://en.wikipedia.org/wiki/ISO_week_date. ga:isoYear should only be used with ga:isoWeek because ga:week represents Gregorian calendar.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5810,7 +6305,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Week of ISO Year",
-        "description": "Combined values of ga:isoYear and ga:isoWeek."
+        "description": "Combined values of ga:isoYear and ga:isoWeek.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5822,7 +6318,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad (GA Model)",
-        "description": "DCM ad name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5834,7 +6331,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad ID (GA Model)",
-        "description": "DCM ad ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5846,7 +6344,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type (GA Model)",
-        "description": "DCM ad type name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad type name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5858,7 +6357,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type ID",
-        "description": "DCM ad type ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad type ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5870,7 +6370,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser (GA Model)",
-        "description": "DCM advertiser name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM advertiser name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5882,7 +6383,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID (GA Model)",
-        "description": "DCM advertiser ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM advertiser ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5894,7 +6396,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign (GA Model)",
-        "description": "DCM campaign name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM campaign name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5906,7 +6409,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign ID (GA Model)",
-        "description": "DCM campaign ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM campaign ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5918,7 +6422,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative ID (GA Model)",
-        "description": "DCM creative ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5930,7 +6435,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative (GA Model)",
-        "description": "DCM creative name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5942,7 +6448,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Rendering ID (GA Model)",
-        "description": "DCM rendering ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM rendering ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5954,7 +6461,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type (GA Model)",
-        "description": "DCM creative type name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative type name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5966,7 +6474,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type ID (GA Model)",
-        "description": "DCM creative type ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative type ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5978,7 +6487,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Version (GA Model)",
-        "description": "DCM creative version of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative version of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5990,7 +6500,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site (GA Model)",
-        "description": "Site name where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only)."
+        "description": "Site name where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6002,7 +6513,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site ID (GA Model)",
-        "description": "DCM site ID where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site ID where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6014,7 +6526,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement (GA Model)",
-        "description": "DCM site placement name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site placement name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6026,7 +6539,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement ID (GA Model)",
-        "description": "DCM site placement ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site placement ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6038,7 +6552,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID (GA Model)",
-        "description": "DCM Floodlight configuration ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM Floodlight configuration ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6050,7 +6565,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity",
-        "description": "DCM Floodlight activity name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6062,7 +6578,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity and Group",
-        "description": "DCM Floodlight activity name and group name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity name and group name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6074,7 +6591,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity Group",
-        "description": "DCM Floodlight activity group name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity group name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6086,7 +6604,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity Group ID",
-        "description": "DCM Floodlight activity group ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity group ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6098,7 +6617,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity ID",
-        "description": "DCM Floodlight activity ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6110,7 +6630,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID",
-        "description": "DCM Floodlight advertiser ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight advertiser ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6122,7 +6643,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID",
-        "description": "DCM Floodlight configuration ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight configuration ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6134,7 +6656,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad",
-        "description": "DCM ad name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6146,7 +6669,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad ID (DFA Model)",
-        "description": "DCM ad ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6158,7 +6682,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type (DFA Model)",
-        "description": "DCM ad type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6170,7 +6695,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type ID (DFA Model)",
-        "description": "DCM ad type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6182,7 +6708,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser (DFA Model)",
-        "description": "DCM advertiser name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM advertiser name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6194,7 +6721,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID (DFA Model)",
-        "description": "DCM advertiser ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM advertiser ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6206,7 +6734,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Attribution Type (DFA Model)",
-        "description": "There are two possible values: ClickThrough and ViewThrough. If the last DCM event associated with the Google Analytics session was a click, then the value will be ClickThrough. If the last DCM event associated with the Google Analytics session was an ad impression, then the value will be ViewThrough (premium only)."
+        "description": "There are two possible values: ClickThrough and ViewThrough. If the last DCM event associated with the Google Analytics session was a click, then the value will be ClickThrough. If the last DCM event associated with the Google Analytics session was an ad impression, then the value will be ViewThrough (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6218,7 +6747,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign (DFA Model)",
-        "description": "DCM campaign name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM campaign name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6230,7 +6760,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign ID (DFA Model)",
-        "description": "DCM campaign ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM campaign ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6242,7 +6773,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative ID (DFA Model)",
-        "description": "DCM creative ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6254,7 +6786,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative (DFA Model)",
-        "description": "DCM creative name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6266,7 +6799,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Rendering ID (DFA Model)",
-        "description": "DCM rendering ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM rendering ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6278,7 +6812,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type (DFA Model)",
-        "description": "DCM creative type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6290,7 +6825,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type ID (DFA Model)",
-        "description": "DCM creative type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6302,7 +6838,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Version (DFA Model)",
-        "description": "DCM creative version of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative version of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6314,7 +6851,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site (DFA Model)",
-        "description": "Site name where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "Site name where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6326,7 +6864,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site ID (DFA Model)",
-        "description": "DCM site ID where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site ID where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6338,7 +6877,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement (DFA Model)",
-        "description": "DCM site placement name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site placement name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6350,7 +6890,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement ID (DFA Model)",
-        "description": "DCM site placement ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site placement ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6362,7 +6903,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID (DFA Model)",
-        "description": "DCM Floodlight configuration ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM Floodlight configuration ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6374,7 +6916,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Conversions",
-        "description": "The number of DCM Floodlight conversions (premium only)."
+        "description": "The number of DCM Floodlight conversions (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6386,7 +6929,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Revenue",
-        "description": "DCM Floodlight revenue (premium only)."
+        "description": "DCM Floodlight revenue (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6398,10 +6942,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 1",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6413,10 +6958,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 2",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6428,10 +6974,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 3",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6443,10 +6990,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 4",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6458,10 +7006,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 5",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6476,7 +7025,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6491,7 +7041,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6506,7 +7057,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6521,7 +7073,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6536,7 +7089,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6548,10 +7102,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 1",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6563,10 +7118,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 2",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6578,10 +7134,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 3",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6593,10 +7150,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 4",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6608,10 +7166,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 5",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6621,12 +7180,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 1",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6636,12 +7196,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 2",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6651,12 +7212,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 3",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6666,12 +7228,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 4",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6681,12 +7244,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 5",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6698,8 +7262,8 @@
         "group": "Audience",
         "status": "PUBLIC",
         "uiName": "Age",
-        "description": "Age bracket of user.",
-        "allowedInSegments": "true"
+        "description": "Age bracket of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6712,8 +7276,8 @@
         "group": "Audience",
         "status": "DEPRECATED",
         "uiName": "Age",
-        "description": "Age bracket of user.",
-        "allowedInSegments": "true"
+        "description": "Age bracket of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6725,8 +7289,8 @@
         "group": "Audience",
         "status": "PUBLIC",
         "uiName": "Gender",
-        "description": "Gender of user.",
-        "allowedInSegments": "true"
+        "description": "Gender of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6739,8 +7303,8 @@
         "group": "Audience",
         "status": "DEPRECATED",
         "uiName": "Gender",
-        "description": "Gender of user.",
-        "allowedInSegments": "true"
+        "description": "Gender of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6753,7 +7317,7 @@
         "status": "PUBLIC",
         "uiName": "Other Category",
         "description": "Indicates that users are more likely to be interested in learning about the specified category, and more likely to be ready to purchase.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6766,7 +7330,7 @@
         "status": "PUBLIC",
         "uiName": "Affinity Category (reach)",
         "description": "Indicates that users are more likely to be interested in learning about the specified category.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6779,7 +7343,7 @@
         "status": "PUBLIC",
         "uiName": "In-Market Segment",
         "description": "Indicates that users are more likely to be ready to purchase products or services in the specified category.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6792,7 +7356,8 @@
         "status": "PUBLIC",
         "uiName": "AdSense Revenue",
         "description": "The total revenue from AdSense ads.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6804,8 +7369,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Ad Units Viewed",
-        "description": "The number of AdSense ad units viewed. An Ad unit is a set of ads displayed as a result of one piece of the AdSense ad code. Details: https://support.google.com/adsense/answer/32715?hl=en",
-        "allowedInSegments": "true"
+        "description": "The number of AdSense ad units viewed. An ad unit is a set of ads displayed as a result of one piece of the AdSense ad code. For details, see https://support.google.com/adsense/answer/32715?hl=en.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6817,8 +7383,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Impressions",
-        "description": "The number of AdSense ads viewed. Multiple ads can be displayed within an Ad Unit.",
-        "allowedInSegments": "true"
+        "description": "The number of AdSense ads viewed. Multiple ads can be displayed within an ad Unit.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6830,8 +7397,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Ads Clicked",
-        "description": "The number of times AdSense ads on your site were clicked.",
-        "allowedInSegments": "true"
+        "description": "The number of times AdSense ads on the site were clicked.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6843,8 +7411,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Page Impressions",
-        "description": "The number of pageviews during which an AdSense ad was displayed. A page impression can have multiple Ad Units.",
-        "allowedInSegments": "true"
+        "description": "The number of pageviews during which an AdSense ad was displayed. A page impression can have multiple ad Units.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6856,8 +7425,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense CTR",
-        "description": "The percentage of page impressions that resulted in a click on an AdSense ad.",
-        "calculation": "ga:adsenseAdsClicks/ga:adsensePageImpressions"
+        "description": "The percentage of page impressions resulted in a click on an AdSense ad.",
+        "calculation": "ga:adsenseAdsClicks/ga:adsensePageImpressions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6869,8 +7439,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense eCPM",
-        "description": "The estimated cost per thousand page impressions. It is your AdSense Revenue per 1000 page impressions.",
-        "calculation": "ga:adsenseRevenue/(ga:adsensePageImpressions/1000)"
+        "description": "The estimated cost per thousand page impressions. It is the AdSense Revenue per 1,000 page impressions.",
+        "calculation": "ga:adsenseRevenue/(ga:adsensePageImpressions/1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6882,8 +7453,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Exits",
-        "description": "The number of sessions that ended due to a user clicking on an AdSense ad.",
-        "allowedInSegments": "true"
+        "description": "The number of sessions ended due to a user clicking on an AdSense ad.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6895,7 +7467,8 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Viewable Impression %",
-        "description": "The percentage of impressions that were viewable."
+        "description": "The percentage of viewable impressions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6907,7 +7480,221 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Coverage",
-        "description": "The percentage of ad requests that returned at least one ad."
+        "description": "The percentage of ad requests that returned at least one ad.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxImpressions",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Impressions",
+        "description": "An Ad Exchange ad impression is reported whenever an individual ad is displayed on the website. For example, if a page with two ad units is viewed once, we'll display two impressions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxCoverage",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Coverage",
+        "description": "Coverage is the percentage of ad requests that returned at least one ad. Generally, coverage can help identify sites where the Ad Exchange account isn't able to provide targeted ads. (Ad Impressions / Total Ad Requests) * 100",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxMonetizedPageviews",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Monetized Pageviews",
+        "description": "This measures the total number of pageviews on the property that were shown with an ad from the linked Ad Exchange account. Note that a single page can have multiple ad units.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxImpressionsPerSession",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Impressions / Session",
+        "description": "The ratio of Ad Exchange ad impressions to Analytics sessions (Ad Impressions / Analytics Sessions).",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxViewableImpressionsPercent",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Viewable Impressions %",
+        "description": "The percentage of viewable ad impressions. An impression is considered a viewable impression when it has appeared within users' browsers and has the opportunity to be seen.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxClicks",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Clicks",
+        "description": "The number of times AdX ads were clicked on the site.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxCTR",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX CTR",
+        "description": "The percentage of pageviews that resulted in a click on an Ad Exchange ad.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxRevenue",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Revenue",
+        "description": "The total estimated revenue from Ad Exchange ads.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxRevenuePer1000Sessions",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Revenue / 1000 Sessions",
+        "description": "The total estimated revenue from Ad Exchange ads per 1,000 Analytics sessions. Note that this metric is based on sessions to the site, not on ad impressions.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxECPM",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX eCPM",
+        "description": "The effective cost per thousand pageviews. It is the Ad Exchange revenue per 1,000 pageviews.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:acquisitionCampaign",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Campaign",
+        "description": "The campaign through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionMedium",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Medium",
+        "description": "The medium through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionSource",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Source",
+        "description": "The source through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionSourceMedium",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Source / Medium",
+        "description": "The combined value of ga:userAcquisitionSource and ga:acquisitionMedium.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionTrafficChannel",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Channel",
+        "description": "Traffic channel through which users were acquired. It is extracted from users' first session. Traffic channel is computed based on the default channel grouping rules (at view level if available) at the time of user acquisition.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:browserSize",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Platform or Device",
+        "status": "PUBLIC",
+        "uiName": "Browser Size",
+        "description": "The viewport size of users' browsers. A session-scoped dimension, browser size captures the initial dimensions of the viewport in pixels and is formatted as width x height, for example, 1920x960.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6919,7 +7706,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Campaign Code",
-        "description": "When using manual campaign tracking, the value of the utm_id campaign tracking parameter."
+        "description": "For manual campaign tracking, it is the value of the utm_id campaign tracking parameter.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6931,8 +7719,9 @@
         "group": "Channel Grouping",
         "status": "PUBLIC",
         "uiName": "Default Channel Grouping",
-        "description": "The default channel grouping that is shared within the View (Profile).",
-        "allowedInSegments": "true"
+        "description": "The default channel grouping shared within the View (Profile).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6944,8 +7733,75 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Checkout Options",
-        "description": "User options specified during the checkout process, e.g., FedEx, DHL, UPS for delivery options or Visa, MasterCard, AmEx for payment options. This dimension should be used along with ga:shoppingStage (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "User options specified during the checkout process, e.g., FedEx, DHL, UPS for delivery options; Visa, MasterCard, AmEx for payment options. This dimension should be used with ga:shoppingStage (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cityId",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "City ID",
+        "description": "Users' city ID, derived from their IP addresses or Geographical IDs. The city IDs are the same as the Criteria IDs found at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cohort",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Cohort",
+        "description": "Name of the cohort to which a user belongs. Depending on how cohorts are defined, a user can belong to multiple cohorts, similar to how a user can belong to multiple segments.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthDay",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Day",
+        "description": "Day offset relative to the cohort definition date. For example, if a cohort is defined with the first visit date as 2015-09-01, then for the date 2015-09-04, ga:cohortNthDay will be 3.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthMonth",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Month",
+        "description": "Month offset relative to the cohort definition date. The semantics of this dimension differs based on whether lifetime value is requested or not. For a cohorts report not requesting lifetime value: This is the week offset from the cohort definition start date. For example, if cohort is defined as 2015-09-01 <= first session date <= 2015-09-30. Then, for 2015-09-01 <= date <= 2015-09-30, ga:cohortNthMonth = 0. 2015-10-01 <= date <= 2015-10-31, ga:cohortNthMonth = 2. and so on. For a cohorts request requesting lifetime value: ga:cohortNthMonth is calculated relative to the users acquisition date. It is not dependent on the cohort definition date. For example, if we define a cohort as 2015-10-01 <= first session date <= 2015-09-30. And a user was acquired on 2015-09-04. Then, for 2015-09-04 <= date <= 2015-10-04, ga:cohortNthMonth = 0 2015-10-04 <= date <= 2015-11-04, ga:cohortNthMonth = 1, and so on.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthWeek",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Week",
+        "description": "Week offset relative to the cohort definition date. The semantics of this dimension differs based on whether lifetime value is requested or not. For a cohorts report not requesting lifetime value: This is the week offset from the cohort definition start date. For example, if cohort is defined as 2015-09-01 <= first session date <= 2015-09-07. Then, for 2015-09-01 <= date <= 2015-09-07, ga:cohortNthWeek = 0. 2015-09-08 <= date <= 2015-09-14, ga:cohortNthWeek = 1. etc. For a cohorts request requesting lifetime value: ga:cohortNthWeek is calculated relative to the users acquisition date. It is not dependent on the cohort definition date. For example, if we define a cohort as 2015-09-01 <= first session date <= 2015-09-07. And a user was acquired on 2015-09-04. Then, for 2015-09-04 <= date<= 2015-09-10, ga:cohortNthWeek = 0 2015-09-11 <= date <= 2015-09-17, ga:cohortNthWeek = 1",
+        "addedInApiVersion": "4"
       }
     },
     {
@@ -6957,7 +7813,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Correlation Model ID",
-        "description": "Correlation Model ID for related products."
+        "description": "Correlation Model ID for related products.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:countryIsoCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Country ISO Code",
+        "description": "Users' country's ISO code (in ISO-3166-1 alpha-2 format), derived from their IP addresses or Geographical IDs. For example, BR for Brazil, CA for Canada.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:dataSource",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Platform or Device",
+        "status": "PUBLIC",
+        "uiName": "Data Source",
+        "description": "The data source of a hit. By default, hits sent from ga.js and analytics.js are reported as \"web\" and hits sent from the mobile SDKs are reported as \"app\". These values can be overridden in the Measurement Protocol.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6970,7 +7855,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Creative",
         "description": "The creative content designed for a promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6983,7 +7869,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion ID",
         "description": "The ID of the promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6996,7 +7883,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Name",
         "description": "The name of the promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7009,7 +7897,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Position",
         "description": "The position of the promotion on the web page or application screen (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7021,7 +7910,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "TrueView Video Ad",
-        "description": "'Yes' or 'No' - Indicates whether the ad is an AdWords TrueView video ad."
+        "description": "A boolean, Yes or No, indicating whether the ad is an AdWords TrueView video ad.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7033,7 +7923,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour Index",
-        "description": "Index for each hour in the specified date range. Index for the first hour of first day (i.e., start-date) in the date range is 0, 1 for the next hour, and so on."
+        "description": "The index for each hour in the specified date range. The index for the first hour of the first day (i.e., start-date) in the date range is 0, for the next hour 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7046,7 +7937,8 @@
         "status": "PUBLIC",
         "uiName": "Order Coupon Code",
         "description": "Code for the order-level coupon (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7059,7 +7951,8 @@
         "status": "PUBLIC",
         "uiName": "Product Brand",
         "description": "The brand name under which the product is sold (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7072,7 +7965,8 @@
         "status": "PUBLIC",
         "uiName": "Product Category (Enhanced Ecommerce)",
         "description": "The hierarchical category in which the product is classified (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7087,7 +7981,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7102,7 +7997,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7117,7 +8013,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7132,7 +8029,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7147,7 +8045,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7160,7 +8059,8 @@
         "status": "PUBLIC",
         "uiName": "Product Coupon Code",
         "description": "Code for the product-level coupon (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7173,7 +8073,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Name",
         "description": "The name of the product list in which the product appears (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7186,7 +8087,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Position",
         "description": "The position of the product in the product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7198,8 +8100,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Variant",
-        "description": "The specific variation of a product, e.g., XS, S, M, L for size or Red, Blue, Green, Black for color (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "The specific variation of a product, e.g., XS, S, M, L for size; or Red, Blue, Green, Black for color (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7211,7 +8114,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product ID",
-        "description": "ID of the product being queried."
+        "description": "ID of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7223,7 +8127,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Name",
-        "description": "Name of the product being queried."
+        "description": "Name of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7235,7 +8140,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Variation",
-        "description": "Variation of the product being queried."
+        "description": "Variation of the product being queried.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:regionId",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Region ID",
+        "description": "Users' region ID, derived from their IP addresses or Geographical IDs. In U.S., a region is a state, New York, for example. The region IDs are the same as the Criteria IDs listed at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:regionIsoCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Region ISO Code",
+        "description": "Users' region ISO code in ISO-3166-2 format, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7247,7 +8181,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product ID",
-        "description": "ID of the related product."
+        "description": "ID of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7259,7 +8194,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Name",
-        "description": "Name of the related product."
+        "description": "Name of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7271,7 +8207,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Variation",
-        "description": "Variation of the related product."
+        "description": "Variation of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7284,7 +8221,21 @@
         "status": "PUBLIC",
         "uiName": "Shopping Stage",
         "description": "Various stages of the shopping experience that users completed in a session, e.g., PRODUCT_VIEW, ADD_TO_CART, CHECKOUT, etc. (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:subContinentCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Sub Continent Code",
+        "description": "Users' sub-continent code in UN M.49 format, derived from their IP addresses or Geographical IDs. For example, 061 for Polynesia, 154 for Northern Europe.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7296,7 +8247,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Buy-to-Detail Rate",
-        "description": "Unique purchases divided by views of product detail pages (Enhanced Ecommerce)."
+        "description": "Unique purchases divided by views of product detail pages (Enhanced Ecommerce).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7308,7 +8260,229 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Cart-to-Detail Rate",
-        "description": "Product adds divided by views of product details (Enhanced Ecommerce)."
+        "description": "Product adds divided by views of product details (Enhanced Ecommerce).",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cohortActiveUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Users",
+        "description": "This metric is relevant in the context of ga:cohortNthDay/ga:cohortNthWeek/ga:cohortNthMonth. It indicates the number of users in the cohort who are active in the time window corresponding to the cohort nth day/week/month. For example, for ga:cohortNthWeek = 1, number of users (in the cohort) who are active in week 1. If a request doesn't have any of ga:cohortNthDay/ga:cohortNthWeek/ga:cohortNthMonth, this metric will have the same value as ga:cohortTotalUsers.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortAppviewsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Appviews per User",
+        "description": "App views per user for a cohort.",
+        "calculation": "ga:appviews / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortAppviewsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Appviews Per User (LTV)",
+        "description": "App views per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:appviews / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortGoalCompletionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Goal Completions per User",
+        "description": "Goal completions per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:goalCompletionsAll / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortGoalCompletionsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Goal Completions Per User (LTV)",
+        "description": "Goal completions per user for a cohort.",
+        "calculation": "ga:goalCompletionsAll / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortPageviewsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Pageviews per User",
+        "description": "Pageviews per user for a cohort.",
+        "calculation": "ga:pageviews / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortPageviewsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Pageviews Per User (LTV)",
+        "description": "Pageviews per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:pageviews / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRetentionRate",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "User Retention",
+        "description": "Cohort retention rate.",
+        "calculation": "ga:cohortActiveUsers / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRevenuePerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Revenue per User",
+        "description": "Revenue per user for a cohort.",
+        "calculation": "ga:transactions / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRevenuePerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Revenue Per User (LTV)",
+        "description": "Revenue per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:transactions / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionDurationPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "TIME",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Session Duration per User",
+        "description": "Session duration per user for a cohort.",
+        "calculation": "ga:sessionDuration / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionDurationPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "TIME",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Session Duration Per User (LTV)",
+        "description": "Session duration per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:sessionDuration / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Sessions per User",
+        "description": "Sessions per user for a cohort.",
+        "calculation": "ga:sessions / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Sessions Per User (LTV)",
+        "description": "Sessions per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:sessions / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortTotalUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Total Users",
+        "description": "Number of users belonging to the cohort, also known as cohort size.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortTotalUsersWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Users",
+        "description": "This is relevant in the context of a request which has the dimensions ga:acquisitionTrafficChannel/ga:acquisitionSource/ga:acquisitionMedium/ga:acquisitionCampaign. It represents the number of users in the cohorts who are acquired through the current channel/source/medium/campaign. For example, for ga:acquisitionTrafficChannel=Direct, it represents the number users in the cohort, who were acquired directly. If none of these mentioned dimensions are present, then its value is equal to ga:cohortTotalUsers.",
+        "addedInApiVersion": "4"
       }
     },
     {
@@ -7320,7 +8494,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Correlation Score",
-        "description": "Correlation Score for related products."
+        "description": "Correlation Score for related products.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7332,7 +8507,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA CPC",
-        "description": "DCM Cost Per Click (premium only)."
+        "description": "DCM Cost Per Click (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7344,7 +8520,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA CTR",
-        "description": "DCM Click Through Rate (premium only)."
+        "description": "DCM Click Through Rate (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7356,7 +8533,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Clicks",
-        "description": "DCM Total Clicks (premium only)."
+        "description": "DCM Total Clicks (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7368,7 +8546,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Cost",
-        "description": "DCM Total Cost (premium only)."
+        "description": "DCM Total Cost (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7380,7 +8559,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Impressions",
-        "description": "DCM Total Impressions (premium only)."
+        "description": "DCM Total Impressions (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7390,9 +8570,23 @@
         "type": "METRIC",
         "dataType": "PERCENT",
         "group": "DoubleClick Campaign Manager",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "DFA Margin",
-        "description": "DCM Margin (premium only)."
+        "description": "This metric is deprecated and will be removed soon. Please use ga:dcmROAS instead.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:dcmROAS",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "DoubleClick Campaign Manager",
+        "status": "PUBLIC",
+        "uiName": "DFA ROAS",
+        "description": "DCM Return On Ad Spend (ROAS) (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7402,9 +8596,10 @@
         "type": "METRIC",
         "dataType": "PERCENT",
         "group": "DoubleClick Campaign Manager",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "DFA ROI",
-        "description": "DCM Return On Investment (premium only)."
+        "description": "This metric is deprecated and will be removed soon. Please use ga:dcmROAS instead.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7416,7 +8611,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA RPC",
-        "description": "DCM Revenue Per Click (premium only)."
+        "description": "DCM Revenue Per Click (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7428,8 +8624,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Hits",
-        "description": "Total number of hits sent to Google Analytics. This metric sums all hit types (e.g. pageview, event, timing, etc.).",
-        "allowedInSegments": "true"
+        "description": "Total number of hits for the view (profile). This metric sums all hit types, including pageview, custom event, ecommerce, and other types. Because this metric is based on the view (profile), not on the property, it is not the same as the property's hit volume.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7442,7 +8639,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion CTR",
         "description": "The rate at which users clicked through to view the internal promotion (ga:internalPromotionClicks / ga:internalPromotionViews) - (Enhanced Ecommerce).",
-        "calculation": "ga:internalPromotionClicks / ga:internalPromotionViews"
+        "calculation": "ga:internalPromotionClicks / ga:internalPromotionViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7455,7 +8653,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Clicks",
         "description": "The number of clicks on an internal promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7468,7 +8667,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Views",
         "description": "The number of views of an internal promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7480,8 +8680,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Product Refund Amount",
-        "description": "Refund amount for a given product in the local currency (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Refund amount in local currency for a given product (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7493,8 +8694,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Refund Amount",
-        "description": "Total refund amount for the transaction in the local currency (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Total refund amount in local currency for the transaction (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7507,7 +8709,8 @@
         "status": "PUBLIC",
         "uiName": "Product Adds To Cart",
         "description": "Number of times the product was added to the shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7520,7 +8723,8 @@
         "status": "PUBLIC",
         "uiName": "Product Checkouts",
         "description": "Number of times the product was included in the check-out process (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7533,7 +8737,8 @@
         "status": "PUBLIC",
         "uiName": "Product Detail Views",
         "description": "Number of times users viewed the product-detail page (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7546,7 +8751,8 @@
         "status": "PUBLIC",
         "uiName": "Product List CTR",
         "description": "The rate at which users clicked through on the product in a product list (ga:productListClicks / ga:productListViews) - (Enhanced Ecommerce).",
-        "calculation": "ga:productListClicks / ga:productListViews"
+        "calculation": "ga:productListClicks / ga:productListViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7559,7 +8765,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Clicks",
         "description": "Number of times users clicked the product when it appeared in the product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7572,7 +8779,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Views",
         "description": "Number of times the product appeared in a product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7585,7 +8793,8 @@
         "status": "PUBLIC",
         "uiName": "Product Refund Amount",
         "description": "Total refund amount associated with the product (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7598,7 +8807,8 @@
         "status": "PUBLIC",
         "uiName": "Product Refunds",
         "description": "Number of times a refund was issued for the product (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7610,8 +8820,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Removes From Cart",
-        "description": "Number of times the product was removed from shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Number of times the product was removed from the shopping cart (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7624,7 +8835,8 @@
         "status": "PUBLIC",
         "uiName": "Product Revenue per Purchase",
         "description": "Average product revenue per purchase (commonly used with Product Coupon Code) (ga:itemRevenue / ga:uniquePurchases) - (Enhanced Ecommerce).",
-        "calculation": "ga:itemRevenue / ga:uniquePurchases"
+        "calculation": "ga:itemRevenue / ga:uniquePurchases",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7637,7 +8849,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Added To Cart",
         "description": "Number of product units added to the shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7650,7 +8863,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Checked Out",
         "description": "Number of product units included in check out (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7663,7 +8877,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Refunded",
         "description": "Number of product units refunded (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7675,8 +8890,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Quantity Removed From Cart",
-        "description": "Number of product units removed from cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Number of product units removed from a shopping cart (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7688,7 +8904,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Quantity",
-        "description": "Quantity of the product being queried."
+        "description": "Quantity of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7701,7 +8918,8 @@
         "status": "PUBLIC",
         "uiName": "Refund Amount",
         "description": "Currency amount refunded for a transaction (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7713,7 +8931,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Quantity",
-        "description": "Quantity of the related product."
+        "description": "Quantity of the related product.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:revenuePerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ecommerce",
+        "status": "PUBLIC",
+        "uiName": "Revenue per User",
+        "description": "The total sale revenue (excluding shipping and tax) of the transaction divided by the total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:sessionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "Number of Sessions per User",
+        "description": "The total number of sessions divided by the total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -7726,7 +8973,22 @@
         "status": "PUBLIC",
         "uiName": "Refunds",
         "description": "Number of refunds that have been issued (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:transactionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Ecommerce",
+        "status": "PUBLIC",
+        "uiName": "Transactions per User",
+        "description": "Total number of transactions divided by total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     }
   ]

--- a/test/_fixtures/metadata-authenticated.json
+++ b/test/_fixtures/metadata-authenticated.json
@@ -1,7 +1,7 @@
 {
   "kind": "analytics#columns",
-  "etag": "\"gUXd2oJOIvAWr2KnYegR9N0sJ7c/Duhub3vzRGEQ1SK4h3jlmcENHac\"",
-  "totalResults": 424,
+  "etag": "\"RTuqIyS1Tt5XEFy6I77L5pEAbZQ/lwy4jM_fkWuurrzNQQUx_Pg44Yc\"",
+  "totalResults": 476,
   "attributeNames": [
     "replacedBy",
     "type",
@@ -16,7 +16,8 @@
     "maxTemplateIndex",
     "premiumMinTemplateIndex",
     "premiumMaxTemplateIndex",
-    "allowedInSegments"
+    "allowedInSegments",
+    "addedInApiVersion"
   ],
   "items": [
     {
@@ -28,8 +29,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "User Type",
-        "description": "A boolean indicating if a user is new or returning. Possible values: New Visitor, Returning Visitor.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either New Visitor or Returning Visitor, indicating if the users are new or returning.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -42,8 +44,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "User Type",
-        "description": "A boolean indicating if a user is new or returning. Possible values: New Visitor, Returning Visitor.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either New Visitor or Returning Visitor, indicating if the users are new or returning.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -55,8 +58,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Count of Sessions",
-        "description": "The session index for a user to your property. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indicies. For example, if a certain user has 4 sessions to your website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
-        "allowedInSegments": "true"
+        "description": "The session index for a user. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indices. For example, if a user has 4 sessions to the website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -69,8 +73,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Count of Sessions",
-        "description": "The session index for a user to your property. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indicies. For example, if a certain user has 4 sessions to your website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
-        "allowedInSegments": "true"
+        "description": "The session index for a user. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indices. For example, if a user has 4 sessions to the website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -82,8 +87,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Days Since Last Session",
-        "description": "The number of days elapsed since users last visited your property. Used to calculate user loyalty.",
-        "allowedInSegments": "true"
+        "description": "The number of days elapsed since users last visited the property, used to calculate user loyalty.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -96,8 +102,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Days Since Last Session",
-        "description": "The number of days elapsed since users last visited your property. Used to calculate user loyalty.",
-        "allowedInSegments": "true"
+        "description": "The number of days elapsed since users last visited the property, used to calculate user loyalty.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -109,8 +116,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "User Defined Value",
-        "description": "The value provided when you define custom user segments for your property.",
-        "allowedInSegments": "true"
+        "description": "The value provided when defining custom user segments for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -122,7 +130,8 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Users",
-        "description": "Total number of users to your property for the requested time period."
+        "description": "The total number of users for the requested time period.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -135,7 +144,8 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Users",
-        "description": "Total number of users to your property for the requested time period."
+        "description": "The total number of users for the requested time period.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -147,8 +157,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "New Users",
-        "description": "The number of users whose session on your property was marked as a first-time session.",
-        "allowedInSegments": "true"
+        "description": "The number of users whose session was marked as a first-time session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -161,8 +172,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "New Users",
-        "description": "The number of users whose session on your property was marked as a first-time session.",
-        "allowedInSegments": "true"
+        "description": "The number of users whose session was marked as a first-time session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -174,8 +186,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "% New Sessions",
-        "description": "The percentage of sessions by people who had never visited your property before.",
-        "calculation": "ga:newUsers / ga:sessions"
+        "description": "The percentage of sessions by users who had never visited the property before.",
+        "calculation": "ga:newUsers / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -188,8 +201,61 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "% New Sessions",
-        "description": "The percentage of sessions by people who had never visited your property before.",
-        "calculation": "ga:newUsers / ga:sessions"
+        "description": "The percentage of sessions by users who had never visited the property before.",
+        "calculation": "ga:newUsers / ga:sessions",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:1dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "1 Day Active Users",
+        "description": "Total number of 1-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 1-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:7dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "7 Day Active Users",
+        "description": "Total number of 7-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 7-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:14dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "14 Day Active Users",
+        "description": "Total number of 14-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 14-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:30dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "30 Day Active Users",
+        "description": "Total number of 30-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 30-day period ending on the given date.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -201,8 +267,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Session Duration",
-        "description": "The length of a session on your property measured in seconds and reported in second increments. The value returned is a string.",
-        "allowedInSegments": "true"
+        "description": "The length (returned as a string) of a session measured in seconds and reported in second increments.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -215,8 +282,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Session Duration",
-        "description": "The length of a session on your property measured in seconds and reported in second increments. The value returned is a string.",
-        "allowedInSegments": "true"
+        "description": "The length (returned as a string) of a session measured in seconds and reported in second increments.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -228,8 +296,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Sessions",
-        "description": "Counts the total number of sessions.",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -242,8 +311,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Sessions",
-        "description": "Counts the total number of sessions.",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -255,8 +325,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Bounces",
-        "description": "The total number of single page (or single engagement hit) sessions for your property.",
-        "allowedInSegments": "true"
+        "description": "The total number of single page (or single engagement hit) sessions for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -270,7 +341,8 @@
         "status": "DEPRECATED",
         "uiName": "Bounce Rate",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:bounceRate instead.",
-        "calculation": "ga:bounces / ga:entrances"
+        "calculation": "ga:bounces / ga:entrances",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -282,8 +354,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Bounce Rate",
-        "description": "The percentage of single-page session (i.e., session in which the person left your property from the first page).",
-        "calculation": "ga:bounces / ga:sessions"
+        "description": "The percentage of single-page session (i.e., session in which the person left the property from the first page).",
+        "calculation": "ga:bounces / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -296,8 +369,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Bounce Rate",
-        "description": "The percentage of single-page session (i.e., session in which the person left your property from the first page).",
-        "calculation": "ga:bounces / ga:sessions"
+        "description": "The percentage of single-page session (i.e., session in which the person left the property from the first page).",
+        "calculation": "ga:bounces / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -309,8 +383,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Session Duration",
-        "description": "The total duration of user sessions represented in total seconds.",
-        "allowedInSegments": "true"
+        "description": "Total duration (in seconds) of users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -323,8 +398,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Session Duration",
-        "description": "The total duration of user sessions represented in total seconds.",
-        "allowedInSegments": "true"
+        "description": "Total duration (in seconds) of users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -336,8 +412,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Avg. Session Duration",
-        "description": "The average duration of user sessions represented in total seconds.",
-        "calculation": "ga:sessionDuration / ga:sessions"
+        "description": "The average duration (in seconds) of users' sessions.",
+        "calculation": "ga:sessionDuration / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -350,8 +427,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Avg. Session Duration",
-        "description": "The average duration of user sessions represented in total seconds.",
-        "calculation": "ga:sessionDuration / ga:sessions"
+        "description": "The average duration (in seconds) of users' sessions.",
+        "calculation": "ga:sessionDuration / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -363,8 +441,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Referral Path",
-        "description": "The path of the referring URL (e.g. document.referrer). If someone places a link to your property on their website, this element contains the path of the page that contains the referring link.",
-        "allowedInSegments": "true"
+        "description": "The path of the referring URL (e.g., document.referrer). If someone places on their webpage a link to the property, this is the path of the page containing the referring link.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -376,7 +455,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Full Referrer",
-        "description": "The full referring URL including the hostname and path."
+        "description": "The full referring URL including the hostname and path.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -388,8 +468,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Campaign",
-        "description": "When using manual campaign tracking, the value of the utm_campaign campaign tracking parameter. When using AdWords autotagging, the name(s) of the online ad campaign that you use for your property. Otherwise the value (not set) is used.",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_campaign campaign tracking parameter. For AdWords autotagging, it is the name(s) of the online ad campaign(s) you use for the property. If you use neither, its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -401,8 +482,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Source",
-        "description": "The source of referrals to your property. When using manual campaign tracking, the value of the utm_source campaign tracking parameter. When using AdWords autotagging, the value is google. Otherwise the domain of the source referring the user to your property (e.g. document.referrer). The value may also contain a port address. If the user arrived without a referrer, the value is (direct)",
-        "allowedInSegments": "true"
+        "description": "The source of referrals. For manual campaign tracking, it is the value of the utm_source campaign tracking parameter. For AdWords autotagging, it is google. If you use neither, it is the domain of the source (e.g., document.referrer) referring the users. It may also contain a port address. If users arrived without a referrer, its value is (direct).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -414,8 +496,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Medium",
-        "description": "The type of referrals to your property. When using manual campaign tracking, the value of the utm_medium campaign tracking parameter. When using AdWords autotagging, the value is ppc. If the user comes from a search engine detected by Google Analytics, the value is organic. If the referrer is not a search engine, the value is referral. If the users came directly to the property, and document.referrer is empty, the value is (none).",
-        "allowedInSegments": "true"
+        "description": "The type of referrals. For manual campaign tracking, it is the value of the utm_medium campaign tracking parameter. For AdWords autotagging, it is ppc. If users came from a search engine detected by Google Analytics, it is organic. If the referrer is not a search engine, it is referral. If users came directly to the property and document.referrer is empty, its value is (none).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -428,7 +511,8 @@
         "status": "PUBLIC",
         "uiName": "Source / Medium",
         "description": "Combined values of ga:source and ga:medium.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -440,8 +524,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Keyword",
-        "description": "When using manual campaign tracking, the value of the utm_term campaign tracking parameter. When using AdWords autotagging or if a user used organic search to reach your property, the keywords used by users to reach your property. Otherwise the value is (not set).",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_term campaign tracking parameter. For AdWords autotagging or when users use organic search to reach the property, it contains the keywords used to reach the property. Otherwise its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -453,8 +538,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Ad Content",
-        "description": "When using manual campaign tracking, the value of the utm_content campaign tracking parameter. When using AdWords autotagging, the first line of the text for your online Ad campaign. If you are using mad libs for your AdWords content, this field displays the keywords you provided for the mad libs keyword match. Otherwise the value is (not set)",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_campaign campaign tracking parameter. For AdWords autotagging, it is the first line of the text for the online Ad campaign. If you use mad libs for the AdWords content, it contains the keywords you provided for the mad libs keyword match. If you use none of the above, its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -466,7 +552,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Social Network",
-        "description": "Name of the social network. This can be related to the referring social network for traffic sources, or to the social network for social data hub activities. E.g. Google+, Blogger, etc."
+        "description": "The social network name. This can be related to the referring social network for traffic sources, or to the social network for social data hub activities; e.g., Google+, Blogger.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -478,7 +565,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Social Source Referral",
-        "description": "Indicates sessions that arrived to the property from a social source. The possible values are Yes or No where the first letter is capitalized."
+        "description": "A boolean, either Yes or No, indicates whether sessions to the property are from a social source.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -490,7 +578,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Organic Searches",
-        "description": "The number of organic searches that happened within a session. This metric is search engine agnostic."
+        "description": "The number of organic searches happened in a session. This metric is search engine agnostic.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -502,8 +591,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Group",
-        "description": "The name of your AdWords ad group.",
-        "allowedInSegments": "true"
+        "description": "The name of the AdWords ad group.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -515,8 +605,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Slot",
-        "description": "The location of the advertisement on the hosting page (Top, RHS, or not set).",
-        "allowedInSegments": "true"
+        "description": "The location (Top, RHS, or not set) of the advertisement on the hosting page.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -526,10 +617,11 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Adwords",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Ad Slot Position",
-        "description": "The ad slot positions in which your AdWords ads appeared (1-8).",
-        "allowedInSegments": "true"
+        "description": "This dimension is deprecated and will soon be removed.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -541,7 +633,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Distribution Network",
-        "description": "The networks used to deliver your ads (Content, Search, Search partners, etc.)."
+        "description": "The network (Content, Search, Search partners, etc.) used to deliver the ads.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -553,7 +646,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Query Match Type",
-        "description": "The match types applied for the search term the user had input(Phrase, Exact, Broad, etc.). Ads on the content network are identified as \"Content network\". Details: https://support.google.com/adwords/answer/2472708?hl=en"
+        "description": "The match type (Phrase, Exact, Broad, etc.) applied for users' search term. Ads on the content network are identified as \"Content network\". For details, see https://support.google.com/adwords/answer/2472708?hl=en.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -565,7 +659,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Keyword Match Type",
-        "description": "The match types applied to your keywords (Phrase, Exact, Broad). Details: https://support.google.com/adwords/answer/2472708?hl=en"
+        "description": "The match type (Phrase, Exact, or Broad) applied to the keywords. For details, see https://support.google.com/adwords/answer/2472708.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -577,7 +672,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Matched Search Query",
-        "description": "The search queries that triggered impressions of your AdWords ads."
+        "description": "The search query that triggered impressions of the AdWords ads.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -589,7 +685,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement Domain",
-        "description": "The domains where your ads on the content network were placed."
+        "description": "The domain where the ads on the content network were placed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -601,7 +698,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement URL",
-        "description": "The URLs where your ads on the content network were placed."
+        "description": "The URL where the ads were placed on the content network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -613,7 +711,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Format",
-        "description": "Your AdWords ad formats (Text, Image, Flash, Video, etc.)."
+        "description": "The AdWords ad format (Text, Image, Flash, Video, etc.).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -625,7 +724,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Targeting Type",
-        "description": "How your AdWords ads were targeted (keyword, placement, and vertical targeting, etc.)."
+        "description": "This (keyword, placement, or vertical targeting) indicates how the AdWords ads were targeted.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -637,7 +738,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement Type",
-        "description": "How you manage your ads on the content network. Values are Automatic placements or Managed placements."
+        "description": "It is Automatic placements or Managed placements, indicating how the ads were managed on the content network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -649,7 +751,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Display URL",
-        "description": "The URLs your AdWords ads displayed."
+        "description": "The URL the AdWords ads displayed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -661,7 +764,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Destination URL",
-        "description": "The URLs to which your AdWords ads referred traffic."
+        "description": "The URL to which the AdWords ads referred traffic.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -673,7 +777,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Customer ID",
-        "description": "A string. Corresponds to AdWords API AccountInfo.customerId."
+        "description": "Customer's AdWords ID, corresponding to AdWords API AccountInfo.customerId.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -685,7 +790,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Campaign ID",
-        "description": "A string. Corresponds to AdWords API Campaign.id."
+        "description": "AdWords API Campaign.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -697,7 +803,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Ad Group ID",
-        "description": "A string. Corresponds to AdWords API AdGroup.id."
+        "description": "AdWords API AdGroup.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -709,7 +816,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Creative ID",
-        "description": "A string. Corresponds to AdWords API Ad.id."
+        "description": "AdWords API Ad.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -721,7 +829,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Criteria ID",
-        "description": "A string. Corresponds to AdWords API Criterion.id."
+        "description": "AdWords API Criterion.id. The geographical targeting Criteria IDs are listed at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -733,7 +842,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Impressions",
-        "description": "Total number of campaign impressions."
+        "description": "Total number of campaign impressions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -745,7 +855,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Clicks",
-        "description": "The total number of times users have clicked on an ad to reach your property."
+        "description": "Total number of times users have clicked on an ad to reach the property.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -757,7 +868,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost",
-        "description": "Derived cost for the advertising campaign. The currency for this value is based on the currency that you set in your AdWords account."
+        "description": "Derived cost for the advertising campaign. Its currency is the one you set in the AdWords account.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -770,7 +882,8 @@
         "status": "PUBLIC",
         "uiName": "CPM",
         "description": "Cost per thousand impressions.",
-        "calculation": "ga:adCost / (ga:impressions / 1000)"
+        "calculation": "ga:adCost / (ga:impressions / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -783,7 +896,8 @@
         "status": "PUBLIC",
         "uiName": "CPC",
         "description": "Cost to advertiser per click.",
-        "calculation": "ga:adCost / ga:adClicks"
+        "calculation": "ga:adCost / ga:adClicks",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -795,8 +909,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "CTR",
-        "description": "Click-through-rate for your ad. This is equal to the number of clicks divided by the number of impressions for your ad (e.g. how many times users clicked on one of your ads where that ad appeared).",
-        "calculation": "ga:adClicks / ga:impressions"
+        "description": "Click-through-rate for the ad. This is equal to the number of clicks divided by the number of impressions for the ad (e.g., how many times users clicked on one of the ads where that ad appeared).",
+        "calculation": "ga:adClicks / ga:impressions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -808,8 +923,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Transaction",
-        "description": "The cost per transaction for your property.",
-        "calculation": "(ga:adCost) / (ga:transactions)"
+        "description": "The cost per transaction for the property.",
+        "calculation": "(ga:adCost) / (ga:transactions)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -821,8 +937,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Goal Conversion",
-        "description": "The cost per goal conversion for your property.",
-        "calculation": "(ga:adCost) / (ga:goalCompletionsAll)"
+        "description": "The cost per goal conversion for the property.",
+        "calculation": "(ga:adCost) / (ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -834,8 +951,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Conversion",
-        "description": "The cost per conversion (including ecommerce and goal conversions) for your property.",
-        "calculation": "(ga:adCost) / (ga:transactions  +  ga:goalCompletionsAll)"
+        "description": "The cost per conversion (including ecommerce and goal conversions) for the property.",
+        "calculation": "(ga:adCost) / (ga:transactions  +  ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -847,8 +965,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "RPC",
-        "description": "RPC or revenue-per-click is the average revenue (from ecommerce sales and/or goal value) you received for each click on one of your search ads.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adClicks"
+        "description": "RPC or revenue-per-click, the average revenue (from ecommerce sales and/or goal value) you received for each click on one of the search ads.",
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adClicks",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -861,7 +980,8 @@
         "status": "DEPRECATED",
         "uiName": "ROI",
         "description": "This metric is deprecated and will be removed soon. Please use ga:ROAS instead.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / ga:adCost"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / ga:adCost",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -874,7 +994,8 @@
         "status": "DEPRECATED",
         "uiName": "Margin",
         "description": "This metric is deprecated and will be removed soon. Please use ga:ROAS instead.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / (ga:transactionRevenue + ga:goalValueAll)"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / (ga:transactionRevenue + ga:goalValueAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -887,7 +1008,21 @@
         "status": "PUBLIC",
         "uiName": "ROAS",
         "description": "Return On Ad Spend (ROAS) is the total transaction revenue and goal value divided by derived advertising cost.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adCost"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adCost",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adQueryWordCount",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Adwords",
+        "status": "PUBLIC",
+        "uiName": "Query Word Count",
+        "description": "The number of words in the search query.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -899,7 +1034,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Completion Location",
-        "description": "The page path or screen name that matched any destination type goal completion."
+        "description": "The page path or screen name that matched any destination type goal completion.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -911,7 +1047,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 1",
-        "description": "The page path or screen name that matched any destination type goal, one step prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, one step prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -923,7 +1060,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 2",
-        "description": "The page path or screen name that matched any destination type goal, two steps prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, two steps prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -935,7 +1073,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 3",
-        "description": "The page path or screen name that matched any destination type goal, three steps prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, three steps prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -950,7 +1089,8 @@
         "description": "The total number of starts for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -965,7 +1105,8 @@
         "description": "The total number of starts for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -980,7 +1121,8 @@
         "description": "The total number of starts for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -992,8 +1134,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Starts",
-        "description": "The total number of starts for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total number of starts for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1008,7 +1151,8 @@
         "description": "The total number of completions for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1023,7 +1167,8 @@
         "description": "The total number of completions for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1038,7 +1183,8 @@
         "description": "The total number of completions for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1050,8 +1196,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Completions",
-        "description": "The total number of completions for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total number of completions for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1066,7 +1213,8 @@
         "description": "The total numeric value for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1081,7 +1229,8 @@
         "description": "The total numeric value for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1096,7 +1245,8 @@
         "description": "The total numeric value for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1108,8 +1258,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Value",
-        "description": "The total numeric value for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total numeric value for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1121,8 +1272,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Per Session Goal Value",
-        "description": "The average goal value of a session on your property.",
-        "calculation": "ga:goalValueAll / ga:sessions"
+        "description": "The average goal value of a session.",
+        "calculation": "ga:goalValueAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1135,8 +1287,9 @@
         "group": "Goal Conversions",
         "status": "DEPRECATED",
         "uiName": "Per Session Goal Value",
-        "description": "The average goal value of a session on your property.",
-        "calculation": "ga:goalValueAll / ga:sessions"
+        "description": "The average goal value of a session.",
+        "calculation": "ga:goalValueAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1148,10 +1301,11 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Checkout complete (Goal 1 Conversion Rate)",
-        "description": "The percentage of sessions which resulted in a conversion to the requested goal number.",
+        "description": "Percentage of sessions resulting in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:sessions",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1163,10 +1317,11 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Create an account (Goal 2 Conversion Rate)",
-        "description": "The percentage of sessions which resulted in a conversion to the requested goal number.",
+        "description": "Percentage of sessions resulting in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:sessions",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1178,10 +1333,11 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Find store location (Goal 3 Conversion Rate)",
-        "description": "The percentage of sessions which resulted in a conversion to the requested goal number.",
+        "description": "Percentage of sessions resulting in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:sessions",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1193,8 +1349,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Conversion Rate",
-        "description": "The percentage of sessions which resulted in a conversion to at least one of your goals.",
-        "calculation": "ga:goalCompletionsAll / ga:sessions"
+        "description": "The percentage of sessions which resulted in a conversion to at least one of the goals.",
+        "calculation": "ga:goalCompletionsAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1209,7 +1366,8 @@
         "description": "The number of times users started conversion activity on the requested goal number without actually completing it.",
         "calculation": "(ga:goalXXStarts - ga:goalXXCompletions)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1224,7 +1382,8 @@
         "description": "The number of times users started conversion activity on the requested goal number without actually completing it.",
         "calculation": "(ga:goalXXStarts - ga:goalXXCompletions)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1239,7 +1398,8 @@
         "description": "The number of times users started conversion activity on the requested goal number without actually completing it.",
         "calculation": "(ga:goalXXStarts - ga:goalXXCompletions)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1252,7 +1412,8 @@
         "status": "PUBLIC",
         "uiName": "Abandoned Funnels",
         "description": "The overall number of times users started goals without actually completing them.",
-        "calculation": "(ga:goalStartsAll - ga:goalCompletionsAll)"
+        "calculation": "(ga:goalStartsAll - ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1267,7 +1428,8 @@
         "description": "The rate at which the requested goal number was abandoned.",
         "calculation": "((ga:goalXXStarts - ga:goalXXCompletions)) / (ga:goalXXStarts)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1282,7 +1444,8 @@
         "description": "The rate at which the requested goal number was abandoned.",
         "calculation": "((ga:goalXXStarts - ga:goalXXCompletions)) / (ga:goalXXStarts)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1297,7 +1460,8 @@
         "description": "The rate at which the requested goal number was abandoned.",
         "calculation": "((ga:goalXXStarts - ga:goalXXCompletions)) / (ga:goalXXStarts)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1309,8 +1473,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Total Abandonment Rate",
-        "description": "The rate at which goals were abandoned.",
-        "calculation": "((ga:goalStartsAll - ga:goalCompletionsAll)) / (ga:goalStartsAll)"
+        "description": "Goal abandonment rate.",
+        "calculation": "((ga:goalStartsAll - ga:goalCompletionsAll)) / (ga:goalStartsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1322,8 +1487,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Browser",
-        "description": "The names of browsers used by users to your website. For example, Internet Explorer or Firefox.",
-        "allowedInSegments": "true"
+        "description": "The name of users' browsers, for example, Internet Explorer or Firefox.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1335,8 +1501,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Browser Version",
-        "description": "The browser versions used by users to your website. For example, 2.0.0.14",
-        "allowedInSegments": "true"
+        "description": "The version of users' browsers, for example, 2.0.0.14.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1348,8 +1515,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Operating System",
-        "description": "The operating system used by your users. For example, Windows, Linux , Macintosh, iPhone, iPod.",
-        "allowedInSegments": "true"
+        "description": "Users' operating system, for example, Windows, Linux, Macintosh, or iOS.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1361,8 +1529,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Operating System Version",
-        "description": "The version of the operating system used by your users, such as XP for Windows or PPC for Macintosh.",
-        "allowedInSegments": "true"
+        "description": "The version of users' operating system, i.e., XP for Windows, PPC for Macintosh.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1375,7 +1544,8 @@
         "status": "DEPRECATED",
         "uiName": "Mobile (Including Tablet)",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:deviceCategory instead (e.g., ga:deviceCategory==mobile).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1388,7 +1558,8 @@
         "status": "DEPRECATED",
         "uiName": "Tablet",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:deviceCategory instead (e.g., ga:deviceCategory==tablet).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1401,7 +1572,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Branding",
         "description": "Mobile manufacturer or branded name.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1413,8 +1585,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Mobile Device Model",
-        "description": "Mobile device model",
-        "allowedInSegments": "true"
+        "description": "Mobile device model.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1426,8 +1599,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Mobile Input Selector",
-        "description": "Selector used on the mobile device (e.g.: touchscreen, joystick, clickwheel, stylus).",
-        "allowedInSegments": "true"
+        "description": "Selector (e.g., touchscreen, joystick, clickwheel, stylus) used on the mobile device.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1440,7 +1614,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Info",
         "description": "The branding, model, and marketing name used to identify the mobile device.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1453,7 +1628,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Marketing Name",
         "description": "The marketing name used for the mobile device.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1466,7 +1642,8 @@
         "status": "PUBLIC",
         "uiName": "Device Category",
         "description": "The type of device: desktop, tablet, or mobile.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1478,8 +1655,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Continent",
-        "description": "The continents of property users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' continents, derived from users' IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1491,8 +1669,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Sub Continent",
-        "description": "The sub-continent of users, derived from IP addresses. For example, Polynesia or Northern Europe.",
-        "allowedInSegments": "true"
+        "description": "Users' sub-continent, derived from their IP addresses or Geographical IDs. For example, Polynesia or Northern Europe.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1504,8 +1683,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Country",
-        "description": "The country of users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' country, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1517,8 +1697,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Region",
-        "description": "The region of users to your property, derived from IP addresses. In the U.S., a region is a state, such as New York.",
-        "allowedInSegments": "true"
+        "description": "Users' region, derived from their IP addresses or Geographical IDs. In U.S., a region is a state, New York, for example.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1530,8 +1711,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Metro",
-        "description": "The Designated Market Area (DMA) from where traffic arrived on your property.",
-        "allowedInSegments": "true"
+        "description": "The Designated Market Area (DMA) from where traffic arrived.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1543,8 +1725,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "City",
-        "description": "The cities of property users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' city, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1556,7 +1739,8 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Latitude",
-        "description": "The approximate latitude of the user's city. Derived from IP address. Locations north of the equator are represented by positive values and locations south of the equator by negative values."
+        "description": "The approximate latitude of users' city, derived from their IP addresses or Geographical IDs. Locations north of the equator have positive latitudes and locations south of the equator have negative latitudes.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1568,7 +1752,8 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Longitude",
-        "description": "The approximate longitude of the user's city. Derived from IP address. Locations east of the meridian are represented by positive values and locations west of the meridian by negative values."
+        "description": "The approximate latitude of users' city, derived from their IP addresses or Geographical IDs. Locations north of the equator have positive latitudes and locations south of the equator have negative latitudes.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1580,8 +1765,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Network Domain",
-        "description": "The domain name of the ISPs used by users to your property. This is derived from the domain name registered to the IP address.",
-        "allowedInSegments": "true"
+        "description": "The domain name of users' ISP, derived from the domain name registered to the ISP's IP address.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1593,8 +1779,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Service Provider",
-        "description": "The name of service providers used to reach your property. For example, if most users to your website come via the major service providers for cable internet, you will see the names of those cable service providers in this element.",
-        "allowedInSegments": "true"
+        "description": "The names of the service providers used to reach the property. For example, if most users of the website come via the major cable internet service providers, its value will be these service providers' names.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1606,8 +1793,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Flash Version",
-        "description": "The versions of Flash supported by users' browsers, including minor versions.",
-        "allowedInSegments": "true"
+        "description": "The version of Flash, including minor versions, supported by users' browsers.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1619,8 +1807,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Java Support",
-        "description": "Indicates Java support for users' browsers. The possible values are Yes or No where the first letter must be capitalized.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either Yes or No, indicating whether Java is enabled in users' browsers.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1632,8 +1821,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Language",
-        "description": "The language provided by the HTTP Request for the browser. Values are given as an ISO-639 code (e.g. en-gb for British English).",
-        "allowedInSegments": "true"
+        "description": "The language, in ISO-639 code format (e.g., en-gb for British English), provided by the HTTP Request for the browser.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1645,8 +1835,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Screen Colors",
-        "description": "The color depth of users' monitors, as retrieved from the DOM of the user's browser. For example 4-bit, 8-bit, 24-bit, or undefined-bit.",
-        "allowedInSegments": "true"
+        "description": "The color depth of users' monitors, retrieved from the DOM of users' browsers. For example, 4-bit, 8-bit, 24-bit, or undefined-bit.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1658,8 +1849,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Source Property Display Name",
-        "description": "Source property display name of roll-up properties. This is valid only for roll-up properties.",
-        "allowedInSegments": "true"
+        "description": "Source property display name of roll-up properties. This is valid for only roll-up properties.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1671,8 +1863,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Source Property Tracking ID",
-        "description": "Source property tracking ID of roll-up properties. This is valid only for roll-up properties.",
-        "allowedInSegments": "true"
+        "description": "Source property tracking ID of roll-up properties. This is valid for only roll-up properties.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1684,8 +1877,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Screen Resolution",
-        "description": "The screen resolution of users' screens. For example: 1024x738.",
-        "allowedInSegments": "true"
+        "description": "Resolution of users' screens, for example, 1024x738.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1695,9 +1889,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Endorsing URL",
-        "description": "For a social data hub activity, this value represents the URL of the social activity (e.g. the Google+ post URL, the blog comment URL, etc.)"
+        "description": "For a social data hub activity, this is the URL of the social activity (e.g., the Google+ post URL, the blog comment URL, etc.).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1707,9 +1902,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Display Name",
-        "description": "For a social data hub activity, this value represents the title of the social activity posted by the social network user."
+        "description": "For a social data hub activity, this is the title of the social activity posted by the social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1719,9 +1915,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Activity Post",
-        "description": "For a social data hub activity, this value represents the content of the social activity posted by the social network user (e.g. The message content of a Google+ post)"
+        "description": "For a social data hub activity, this is the content of the social activity (e.g., the content of a message posted in Google+) posted by social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1731,9 +1928,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Activity Timestamp",
-        "description": "For a social data hub activity, this value represents when the social activity occurred on the social network."
+        "description": "For a social data hub activity, this is the time when the social activity occurred on the social network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1743,9 +1941,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social User Handle",
-        "description": "For a social data hub activity, this value represents the social network handle (e.g. name or ID) of the user who initiated the social activity."
+        "description": "For a social data hub activity, this is the social network handle (e.g., name or ID) of users who initiated the social activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1755,9 +1954,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "User Photo URL",
-        "description": "For a social data hub activity, this value represents the URL of the photo associated with the user's social network profile."
+        "description": "For a social data hub activity, this is the URL of the photo associated with users' social network profiles.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1767,9 +1967,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "User Profile URL",
-        "description": "For a social data hub activity, this value represents the URL of the associated user's social network profile."
+        "description": "For a social data hub activity, this is the URL of the associated users' social network profiles.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1779,9 +1980,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Shared URL",
-        "description": "For a social data hub activity, this value represents the URL shared by the associated social network user."
+        "description": "For a social data hub activity, this is the URL shared by the associated social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1791,9 +1993,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Tags Summary",
-        "description": "For a social data hub activity, this is a comma-separated set of tags associated with the social activity."
+        "description": "For a social data hub activity, this is a comma-separated set of tags associated with the social activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1803,9 +2006,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Originating Social Action",
-        "description": "For a social data hub activity, this value represents the type of social action associated with the activity (e.g. vote, comment, +1, etc.)."
+        "description": "For a social data hub activity, this represents the type of social action (e.g., vote, comment, +1, etc.) associated with the activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1815,9 +2019,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Network and Action",
-        "description": "For a social data hub activity, this value represents the type of social action and the social network where the activity originated."
+        "description": "For a social data hub activity, this is the type of social action and the social network where the activity originated.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1827,9 +2032,10 @@
         "type": "METRIC",
         "dataType": "INTEGER",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Data Hub Activities",
-        "description": "The count of activities where a content URL was shared / mentioned on a social data hub partner network."
+        "description": "Total number of activities where a content URL was shared or mentioned on a social data hub partner network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1842,7 +2048,8 @@
         "status": "PUBLIC",
         "uiName": "Hostname",
         "description": "The hostname from which the tracking request was made.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1854,8 +2061,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page",
-        "description": "A page on your website specified by path and/or query parameters. Use in conjunction with hostname to get the full URL of the page.",
-        "allowedInSegments": "true"
+        "description": "A page on the website specified by path and/or query parameters. Use this with hostname to get the page's full URL.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1867,7 +2075,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 1",
-        "description": "This dimension rolls up all the page paths in the first hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the first hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1879,7 +2088,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 2",
-        "description": "This dimension rolls up all the page paths in the second hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the second hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1891,7 +2101,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 3",
-        "description": "This dimension rolls up all the page paths in the third hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the third hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1903,7 +2114,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 4",
-        "description": "This dimension rolls up all the page paths into hierarchical levels. Up to 4 pagePath levels maybe specified. All additional levels in the pagePath hierarchy are also rolled up in this dimension."
+        "description": "This dimension rolls up all the page paths into hierarchical levels. Up to 4 pagePath levels maybe specified. All additional levels in the pagePath hierarchy are also rolled up in this dimension.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1915,8 +2127,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page Title",
-        "description": "The title of a page. Keep in mind that multiple pages might have the same page title.",
-        "allowedInSegments": "true"
+        "description": "The page's title. Multiple pages might have the same page title.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1928,8 +2141,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Landing Page",
-        "description": "The first page in a user's session, or landing page.",
-        "allowedInSegments": "true"
+        "description": "The first page in users' sessions, or the landing page.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1941,7 +2155,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Second Page",
-        "description": "The second page in a user's session."
+        "description": "The second page in users' sessions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1953,8 +2168,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Exit Page",
-        "description": "The last page in a user's session, or exit page.",
-        "allowedInSegments": "true"
+        "description": "The last page or exit page in users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1966,7 +2182,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Previous Page Path",
-        "description": "A page on your property that was visited before another page on the same property. Typically used with the pagePath dimension."
+        "description": "A page visited before another page on the same property, typically used with the pagePath dimension.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1976,9 +2193,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Page Tracking",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Path",
-        "description": "A page on your website that was visited after another page on your website. Typically used with the previousPagePath dimension."
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:pagePath instead.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1991,7 +2209,8 @@
         "status": "PUBLIC",
         "uiName": "Page Depth",
         "description": "The number of pages visited by users during a session. The value is a histogram that counts pageviews across a range of possible values. In this calculation, all sessions will have at least one pageview, and some percentage of sessions will have more.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2003,7 +2222,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page Value",
-        "description": "The average value of this page or set of pages. Page Value is (ga:transactionRevenue + ga:goalValueAll) / ga:uniquePageviews (for the page or set of pages)."
+        "description": "The average value of this page or set of pages, which is equal to (ga:transactionRevenue + ga:goalValueAll) / ga:uniquePageviews.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2015,8 +2235,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Entrances",
-        "description": "The number of entrances to your property measured as the first pageview in a session. Typically used with landingPagePath",
-        "allowedInSegments": "true"
+        "description": "The number of entrances to the property measured as the first pageview in a session, typically used with landingPagePath.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2029,7 +2250,8 @@
         "status": "PUBLIC",
         "uiName": "Entrances / Pageviews",
         "description": "The percentage of pageviews in which this page was the entrance.",
-        "calculation": "ga:entrances / ga:pageviews"
+        "calculation": "ga:entrances / ga:pageviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2041,8 +2263,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Pageviews",
-        "description": "The total number of pageviews for your property.",
-        "allowedInSegments": "true"
+        "description": "The total number of pageviews for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2054,8 +2277,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Pages / Session",
-        "description": "The average number of pages viewed during a session on your property. Repeated views of a single page are counted.",
-        "calculation": "ga:pageviews / ga:sessions"
+        "description": "The average number of pages viewed during a session, including repeated views of a single page.",
+        "calculation": "ga:pageviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2068,8 +2292,9 @@
         "group": "Page Tracking",
         "status": "DEPRECATED",
         "uiName": "Pages / Session",
-        "description": "The average number of pages viewed during a session on your property. Repeated views of a single page are counted.",
-        "calculation": "ga:pageviews / ga:sessions"
+        "description": "The average number of pages viewed during a session, including repeated views of a single page.",
+        "calculation": "ga:pageviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2081,9 +2306,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 1",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2095,9 +2321,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 2",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2109,9 +2336,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 3",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2123,9 +2351,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 4",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2137,9 +2366,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views 5",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2151,8 +2381,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Pageviews",
-        "description": "The number of different (unique) pages within a session. This takes into account both the pagePath and pageTitle to determine uniqueness.",
-        "allowedInSegments": "true"
+        "description": "The number of unique page views. Page views in different sessions are counted as unique page views. Both the pagePath and pageTitle are used to determine page view uniqueness.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2164,8 +2395,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Time on Page",
-        "description": "How long a user spent on a particular page in seconds. Calculated by subtracting the initial view time for a particular page from the initial view time for a subsequent page. Thus, this metric does not apply to exit pages for your property.",
-        "allowedInSegments": "true"
+        "description": "Time (in seconds) users spent on a particular page, calculated by subtracting the initial view time for a particular page from the initial view time for a subsequent page. This metric does not apply to exit pages of the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2177,8 +2409,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Avg. Time on Page",
-        "description": "The average amount of time users spent viewing this page or a set of pages.",
-        "calculation": "ga:timeOnPage / (ga:pageviews - ga:exits)"
+        "description": "The average time users spent viewing this page or a set of pages.",
+        "calculation": "ga:timeOnPage / (ga:pageviews - ga:exits)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2190,8 +2423,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Exits",
-        "description": "The number of exits from your property.",
-        "allowedInSegments": "true"
+        "description": "The number of exits from the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2203,8 +2437,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "% Exit",
-        "description": "The percentage of exits from your property that occurred out of the total page views.",
-        "calculation": "ga:exits / (ga:pageviews + ga:screenviews)"
+        "description": "The percentage of exits from the property that occurred out of the total pageviews.",
+        "calculation": "ga:exits / (ga:pageviews + ga:screenviews)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2216,8 +2451,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Status",
-        "description": "A boolean to distinguish whether internal search was used in a session. Values are Visits With Site Search and Visits Without Site Search.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either Visits With Site Search or Visits Without Site Search, to distinguish whether internal search was used in a session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2229,8 +2465,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Term",
-        "description": "Search terms used by users within your property.",
-        "allowedInSegments": "true"
+        "description": "Search term used within the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2242,8 +2479,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Refined Keyword",
-        "description": "Subsequent keyword search terms or strings entered by users after a given initial string search.",
-        "allowedInSegments": "true"
+        "description": "Subsequent keyword search term or string entered by users after a given initial string search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2255,8 +2493,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Category",
-        "description": "The categories used for the internal search if you have this enabled for your profile. For example, you might have product categories such as electronics, furniture, or clothing.",
-        "allowedInSegments": "true"
+        "description": "The category used for the internal search if site search categories are enabled in the view. For example, the product category may be electronics, furniture, or clothing.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2268,7 +2507,8 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Start Page",
-        "description": "A page where the user initiated an internal search on your property."
+        "description": "The page where users initiated an internal search.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2280,7 +2520,22 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Destination Page",
-        "description": "The page the user immediately visited after performing an internal search on your site. (Usually the search results page)."
+        "description": "The page users immediately visited after performing an internal search on the site. This is usually the search results page.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:searchAfterDestinationPage",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Internal Search",
+        "status": "PUBLIC",
+        "uiName": "Search Destination Page",
+        "description": "The page that users visited after performing an internal search on the site.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2292,7 +2547,8 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Results Pageviews",
-        "description": "The number of times a search result page was viewed after performing a search."
+        "description": "The number of times a search result page was viewed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2304,8 +2560,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Total Unique Searches",
-        "description": "The total number of unique keywords from internal searches within a session. For example if \"shoes\" was searched for 3 times in a session, it will be only counted once.",
-        "allowedInSegments": "true"
+        "description": "Total number of unique keywords from internal searches within a session. For example, if \"shoes\" was searched for 3 times in a session, it would be counted only once.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2317,8 +2574,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Results Pageviews / Search",
-        "description": "The average number of times people viewed a search results page after performing a search.",
-        "calculation": "ga:searchResultViews / ga:searchUniques"
+        "description": "The average number of times people viewed a page as a result of a search.",
+        "calculation": "ga:searchResultViews / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2330,8 +2588,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Sessions with Search",
-        "description": "The total number of sessions that included an internal search",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions that included an internal search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2344,8 +2603,9 @@
         "group": "Internal Search",
         "status": "DEPRECATED",
         "uiName": "Sessions with Search",
-        "description": "The total number of sessions that included an internal search",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions that included an internal search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2358,7 +2618,8 @@
         "status": "PUBLIC",
         "uiName": "% Sessions with Search",
         "description": "The percentage of sessions with search.",
-        "calculation": "ga:searchSessions / ga:sessions"
+        "calculation": "ga:searchSessions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2372,7 +2633,8 @@
         "status": "DEPRECATED",
         "uiName": "% Sessions with Search",
         "description": "The percentage of sessions with search.",
-        "calculation": "ga:searchSessions / ga:sessions"
+        "calculation": "ga:searchSessions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2384,8 +2646,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Depth",
-        "description": "The average number of subsequent page views made on your property after a use of your internal search feature.",
-        "allowedInSegments": "true"
+        "description": "The total number of subsequent page views made after a use of the site's internal search feature.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2397,8 +2660,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Average Search Depth",
-        "description": "The average number of pages people viewed after performing a search on your property.",
-        "calculation": "ga:searchDepth / ga:searchUniques"
+        "description": "The average number of pages people viewed after performing a search.",
+        "calculation": "ga:searchDepth / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2410,8 +2674,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Refinements",
-        "description": "The total number of times a refinement (transition) occurs between internal search keywords within a session. For example if the sequence of keywords is: \"shoes\", \"shoes\", \"pants\", \"pants\", this metric will be one because the transition between \"shoes\" and \"pants\" is different.",
-        "allowedInSegments": "true"
+        "description": "The total number of times a refinement (transition) occurs between internal keywords search within a session. For example, if the sequence of keywords is \"shoes\", \"shoes\", \"pants\", \"pants\", this metric will be one because the transition between \"shoes\" and \"pants\" is different.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2423,8 +2688,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "% Search Refinements",
-        "description": "The percentage of number of times a refinement (i.e., transition) occurs between internal search keywords within a session.",
-        "calculation": "ga:searchRefinements / ga:searchResultViews"
+        "description": "The percentage of the number of times a refinement (i.e., transition) occurs between internal keywords search within a session.",
+        "calculation": "ga:searchRefinements / ga:searchResultViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2436,8 +2702,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Time after Search",
-        "description": "The session duration on your property where a use of your internal search feature occurred.",
-        "allowedInSegments": "true"
+        "description": "The session duration when the site's internal search feature is used.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2449,8 +2716,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Time after Search",
-        "description": "The average amount of time people spent on your property after searching.",
-        "calculation": "ga:searchDuration / ga:searchUniques"
+        "description": "The average time (in seconds) users, after searching, spent on the property.",
+        "calculation": "ga:searchDuration / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2462,8 +2730,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Exits",
-        "description": "The number of exits on your site that occurred following a search result from your internal search feature.",
-        "allowedInSegments": "true"
+        "description": "The number of exits on the site that occurred following a search result from the site's internal search feature.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2475,8 +2744,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "% Search Exits",
-        "description": "The percentage of searches that resulted in an immediate exit from your property.",
-        "calculation": "ga:searchExits / ga:searchUniques"
+        "description": "The percentage of searches that resulted in an immediate exit from the property.",
+        "calculation": "ga:searchExits / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2491,7 +2761,8 @@
         "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:searchUniques",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2506,7 +2777,8 @@
         "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:searchUniques",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2521,7 +2793,8 @@
         "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:searchUniques",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2533,8 +2806,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Goal Conversion Rate",
-        "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to at least one of your goals.",
-        "calculation": "ga:goalCompletionsAll / ga:searchUniques"
+        "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to at least one of the goals.",
+        "calculation": "ga:goalCompletionsAll / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2546,8 +2820,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Per Search Goal Value",
-        "description": "The average goal value of a search on your property.",
-        "calculation": "ga:goalValueAll / ga:searchUniques"
+        "description": "The average goal value of a search.",
+        "calculation": "ga:goalValueAll / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2559,7 +2834,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Load Time (ms)",
-        "description": "Total Page Load Time is the amount of time (in milliseconds) it takes for pages from the sample set to load, from initiation of the pageview (e.g. click on a page link) to load completion in the browser."
+        "description": "Total time (in milliseconds), from pageview initiation (e.g., a click on a page link) to page load completion in the browser, the pages in the sample set take to load.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2571,7 +2847,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Load Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the average page load time."
+        "description": "The sample set (or count) of pageviews used to calculate the average page load time.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2583,8 +2860,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Page Load Time (sec)",
-        "description": "The average amount of time (in seconds) it takes for pages from the sample set to load, from initiation of the pageview (e.g. click on a page link) to load completion in the browser.",
-        "calculation": "(ga:pageLoadTime / ga:pageLoadSample / 1000)"
+        "description": "The average time (in seconds) pages from the sample set take to load, from initiation of the pageview (e.g., a click on a page link) to load completion in the browser.",
+        "calculation": "(ga:pageLoadTime / ga:pageLoadSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2596,7 +2874,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Domain Lookup Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in DNS lookup for this page among all samples."
+        "description": "The total time (in milliseconds) all samples spent in DNS lookup for this page.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2608,8 +2887,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Domain Lookup Time (sec)",
-        "description": "The average amount of time (in seconds) spent in DNS lookup for this page.",
-        "calculation": "(ga:domainLookupTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in DNS lookup for this page.",
+        "calculation": "(ga:domainLookupTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2621,7 +2901,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Download Time (ms)",
-        "description": "The total amount of time (in milliseconds) to download this page among all samples."
+        "description": "The total time (in milliseconds) to download this page among all samples.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2633,8 +2914,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Page Download Time (sec)",
-        "description": "The average amount of time (in seconds) to download this page.",
-        "calculation": "(ga:pageDownloadTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) to download this page.",
+        "calculation": "(ga:pageDownloadTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2646,7 +2928,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Redirection Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in redirects before fetching this page among all samples. If there are no redirects, the value for this metric is expected to be 0."
+        "description": "The total time (in milliseconds) all samples spent in redirects before fetching this page. If there are no redirects, this is 0.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2658,8 +2941,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Redirection Time (sec)",
-        "description": "The average amount of time (in seconds) spent in redirects before fetching this page. If there are no redirects, the value for this metric is expected to be 0.",
-        "calculation": "(ga:redirectionTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in redirects before fetching this page. If there are no redirects, this is 0.",
+        "calculation": "(ga:redirectionTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2671,7 +2955,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Server Connection Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in establishing TCP connection for this page among all samples."
+        "description": "Total time (in milliseconds) all samples spent in establishing a TCP connection to this page.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2683,8 +2968,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Server Connection Time (sec)",
-        "description": "The average amount of time (in seconds) spent in establishing TCP connection for this page.",
-        "calculation": "(ga:serverConnectionTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in establishing a TCP connection to this page.",
+        "calculation": "(ga:serverConnectionTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2696,7 +2982,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Server Response Time (ms)",
-        "description": "The total amount of time (in milliseconds) your server takes to respond to a user request among all samples, including the network time from user's location to your server."
+        "description": "The total time (in milliseconds) the site's server takes to respond to users' requests among all samples; this includes the network time from users' locations to the server.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2708,8 +2995,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Server Response Time (sec)",
-        "description": "The average amount of time (in seconds) your server takes to respond to a user request, including the network time from user's location to your server.",
-        "calculation": "(ga:serverResponseTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) the site's server takes to respond to users' requests; this includes the network time from users' locations to the server.",
+        "calculation": "(ga:serverResponseTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2721,7 +3009,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Speed Metrics Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the averages for site speed metrics. This metric is used in all site speed average calculations including avgDomainLookupTime, avgPageDownloadTime, avgRedirectionTime, avgServerConnectionTime, and avgServerResponseTime."
+        "description": "The sample set (or count) of pageviews used to calculate the averages of site speed metrics. This metric is used in all site speed average calculations, including avgDomainLookupTime, avgPageDownloadTime, avgRedirectionTime, avgServerConnectionTime, and avgServerResponseTime.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2733,7 +3022,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Document Interactive Time (ms)",
-        "description": "The time the browser takes (in milliseconds) to parse the document (DOMInteractive), including the network time from the user's location to your server. At this time, the user can interact with the Document Object Model even though it is not fully loaded."
+        "description": "The time (in milliseconds), including the network time from users' locations to the site's server, the browser takes to parse the document (DOMInteractive). At this time, users can interact with the Document Object Model even though it is not fully loaded.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2745,8 +3035,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Document Interactive Time (sec)",
-        "description": "The average time (in seconds) it takes the browser to parse the document and execute deferred and parser-inserted scripts including the network time from the user's location to your server.",
-        "calculation": "(ga:domInteractiveTime / ga:domLatencyMetricsSample / 1000)"
+        "description": "The average time (in seconds), including the network time from users' locations to the site's server, the browser takes to parse the document and execute deferred and parser-inserted scripts.",
+        "calculation": "(ga:domInteractiveTime / ga:domLatencyMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2758,7 +3049,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Document Content Loaded Time (ms)",
-        "description": "The time the browser takes (in milliseconds) to parse the document and execute deferred and parser-inserted scripts (DOMContentLoaded), including the network time from the user's location to your server. Parsing of the document is finished, the Document Object Model is ready, but referenced style sheets, images, and subframes may not be finished loading. This event is often the starting point for javascript framework execution, e.g., JQuery's onready() callback, etc."
+        "description": "The time (in milliseconds), including the network time from users' locations to the site's server, the browser takes to parse the document and execute deferred and parser-inserted scripts (DOMContentLoaded). When parsing of the document is finished, the Document Object Model (DOM) is ready, but the referenced style sheets, images, and subframes may not be finished loading. This is often the starting point of Javascript framework execution, e.g., JQuery's onready() callback.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2770,8 +3062,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Document Content Loaded Time (sec)",
-        "description": "The average time (in seconds) it takes the browser to parse the document.",
-        "calculation": "(ga:domContentLoadedTime / ga:domLatencyMetricsSample / 1000)"
+        "description": "The average time (in seconds) the browser takes to parse the document.",
+        "calculation": "(ga:domContentLoadedTime / ga:domLatencyMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2783,7 +3076,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "DOM Latency Metrics Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the averages for site speed DOM metrics. This metric is used in the avgDomContentLoadedTime and avgDomInteractiveTime calculations."
+        "description": "Sample set (or count) of pageviews used to calculate the averages for site speed DOM metrics. This metric is used to calculate ga:avgDomContentLoadedTime and ga:avgDomInteractiveTime.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2795,8 +3089,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Installer ID",
-        "description": "ID of the installer (e.g., Google Play Store) from which the app was downloaded. By default, the app installer id is set based on the PackageManager#getInstallerPackageName method.",
-        "allowedInSegments": "true"
+        "description": "The ID of the app installer (e.g., Google Play Store) from which the app was downloaded. By default, the app installer ID is set by the PackageManager#getInstallerPackageName method.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2808,8 +3103,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Version",
-        "description": "The version of the application.",
-        "allowedInSegments": "true"
+        "description": "The application version.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2821,8 +3117,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Name",
-        "description": "The name of the application.",
-        "allowedInSegments": "true"
+        "description": "The application name.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2834,8 +3131,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App ID",
-        "description": "The ID of the application.",
-        "allowedInSegments": "true"
+        "description": "The application ID.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2848,7 +3146,8 @@
         "status": "PUBLIC",
         "uiName": "Screen Name",
         "description": "The name of the screen.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2860,8 +3159,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Screen Depth",
-        "description": "The number of screenviews per session reported as a string. Can be useful for historgrams.",
-        "allowedInSegments": "true"
+        "description": "The number of screenviews (reported as a string) per session, useful for historgrams.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2873,8 +3173,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Landing Screen",
-        "description": "The name of the first screen viewed.",
-        "allowedInSegments": "true"
+        "description": "The name of the first viewed screen.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2886,8 +3187,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Exit Screen",
-        "description": "The name of the screen when the user exited the application.",
-        "allowedInSegments": "true"
+        "description": "The name of the screen where users exited the application.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2900,7 +3202,8 @@
         "status": "PUBLIC",
         "uiName": "Screen Views",
         "description": "The total number of screenviews.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2914,7 +3217,8 @@
         "status": "DEPRECATED",
         "uiName": "Screen Views",
         "description": "The total number of screenviews.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2926,8 +3230,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Screen Views",
-        "description": "The number of different (unique) screenviews within a session.",
-        "allowedInSegments": "true"
+        "description": "The number of unique screen views. Screen views in different sessions are counted as separate screen views.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2940,8 +3245,9 @@
         "group": "App Tracking",
         "status": "DEPRECATED",
         "uiName": "Unique Screen Views",
-        "description": "The number of different (unique) screenviews within a session.",
-        "allowedInSegments": "true"
+        "description": "The number of unique screen views. Screen views in different sessions are counted as separate screen views.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2954,7 +3260,8 @@
         "status": "PUBLIC",
         "uiName": "Screens / Session",
         "description": "The average number of screenviews per session.",
-        "calculation": "ga:screenviews / ga:sessions"
+        "calculation": "ga:screenviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2968,7 +3275,8 @@
         "status": "DEPRECATED",
         "uiName": "Screens / Session",
         "description": "The average number of screenviews per session.",
-        "calculation": "ga:screenviews / ga:sessions"
+        "calculation": "ga:screenviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2981,7 +3289,8 @@
         "status": "PUBLIC",
         "uiName": "Time on Screen",
         "description": "The time spent viewing the current screen.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2993,7 +3302,8 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Avg. Time on Screen",
-        "description": "The average amount of time users spent on a screen in seconds."
+        "description": "Average time (in seconds) users spent on a screen.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3005,8 +3315,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Category",
-        "description": "The category of the event.",
-        "allowedInSegments": "true"
+        "description": "The event category.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3018,8 +3329,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Action",
-        "description": "The action of the event.",
-        "allowedInSegments": "true"
+        "description": "Event action.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3031,8 +3343,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Label",
-        "description": "The label of the event.",
-        "allowedInSegments": "true"
+        "description": "Event label.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3045,7 +3358,8 @@
         "status": "PUBLIC",
         "uiName": "Total Events",
         "description": "The total number of events for the profile, across all categories.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3057,7 +3371,8 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Events",
-        "description": "The total number of unique events for the profile, across all categories."
+        "description": "The number of unique events. Events in different sessions are counted as separate events.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3069,8 +3384,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Value",
-        "description": "The total value of events for the profile.",
-        "allowedInSegments": "true"
+        "description": "Total value of events for the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3083,7 +3399,8 @@
         "status": "PUBLIC",
         "uiName": "Avg. Value",
         "description": "The average value of an event.",
-        "calculation": "ga:eventValue / ga:totalEvents"
+        "calculation": "ga:eventValue / ga:totalEvents",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3096,7 +3413,8 @@
         "status": "PUBLIC",
         "uiName": "Sessions with Event",
         "description": "The total number of sessions with events.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3110,7 +3428,8 @@
         "status": "DEPRECATED",
         "uiName": "Sessions with Event",
         "description": "The total number of sessions with events.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3123,7 +3442,8 @@
         "status": "PUBLIC",
         "uiName": "Events / Session with Event",
         "description": "The average number of events per session with event.",
-        "calculation": "ga:totalEvents / ga:sessionsWithEvent"
+        "calculation": "ga:totalEvents / ga:sessionsWithEvent",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3137,7 +3457,8 @@
         "status": "DEPRECATED",
         "uiName": "Events / Session with Event",
         "description": "The average number of events per session with event.",
-        "calculation": "ga:totalEvents / ga:sessionsWithEvent"
+        "calculation": "ga:totalEvents / ga:sessionsWithEvent",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3149,8 +3470,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Transaction ID",
-        "description": "The transaction ID for the shopping cart purchase as supplied by your ecommerce tracking method.",
-        "allowedInSegments": "true"
+        "description": "The transaction ID, supplied by the ecommerce tracking method, for the purchase in the shopping cart.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3162,8 +3484,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Affiliation",
-        "description": "Typically used to designate a supplying company or brick and mortar location; product affiliation.",
-        "allowedInSegments": "true"
+        "description": "A product affiliation to designate a supplying company or brick and mortar location.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3176,7 +3499,8 @@
         "status": "PUBLIC",
         "uiName": "Sessions to Transaction",
         "description": "The number of sessions between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3190,7 +3514,8 @@
         "status": "DEPRECATED",
         "uiName": "Sessions to Transaction",
         "description": "The number of sessions between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3203,7 +3528,8 @@
         "status": "PUBLIC",
         "uiName": "Days to Transaction",
         "description": "The number of days between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3215,8 +3541,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product SKU",
-        "description": "The product sku for purchased items as you have defined them in your ecommerce tracking application.",
-        "allowedInSegments": "true"
+        "description": "The product SKU, defined in the ecommerce tracking application, for purchased items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3228,8 +3555,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product",
-        "description": "The product name for purchased items as supplied by your ecommerce tracking application.",
-        "allowedInSegments": "true"
+        "description": "The product name, supplied by the ecommerce tracking application, for purchased items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3241,8 +3569,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Category",
-        "description": "Any product variations (size, color) for purchased items as supplied by your ecommerce application. Not compatible with Enhanced Ecommerce.",
-        "allowedInSegments": "true"
+        "description": "Any product variation (size, color) supplied by the ecommerce application for purchased items, not compatible with Enhanced Ecommerce.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3254,7 +3583,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Currency Code",
-        "description": "The local currency code of the transaction based on ISO 4217 standard."
+        "description": "The local currency code (based on ISO 4217 standard) of the transaction.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3267,7 +3597,8 @@
         "status": "PUBLIC",
         "uiName": "Transactions",
         "description": "The total number of transactions.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3279,8 +3610,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Ecommerce Conversion Rate",
-        "description": "The average number of transactions for a session on your property.",
-        "calculation": "ga:transactions / ga:sessions"
+        "description": "The average number of transactions in a session.",
+        "calculation": "ga:transactions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3293,8 +3625,9 @@
         "group": "Ecommerce",
         "status": "DEPRECATED",
         "uiName": "Ecommerce Conversion Rate",
-        "description": "The average number of transactions for a session on your property.",
-        "calculation": "ga:transactions / ga:sessions"
+        "description": "The average number of transactions in a session.",
+        "calculation": "ga:transactions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3306,8 +3639,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Revenue",
-        "description": "The total sale revenue provided in the transaction excluding shipping and tax.",
-        "allowedInSegments": "true"
+        "description": "The total sale revenue (excluding shipping and tax) of the transaction.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3319,8 +3653,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Average Order Value",
-        "description": "The average revenue for an e-commerce transaction.",
-        "calculation": "ga:transactionRevenue / ga:transactions"
+        "description": "The average revenue of an ecommerce transaction.",
+        "calculation": "ga:transactionRevenue / ga:transactions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3332,8 +3667,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Per Session Value",
-        "description": "Average transaction revenue for a session on your property.",
-        "calculation": "ga:transactionRevenue / ga:sessions"
+        "description": "Average transaction revenue for a session.",
+        "calculation": "ga:transactionRevenue / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3346,8 +3682,9 @@
         "group": "Ecommerce",
         "status": "DEPRECATED",
         "uiName": "Per Session Value",
-        "description": "Average transaction revenue for a session on your property.",
-        "calculation": "ga:transactionRevenue / ga:sessions"
+        "description": "Average transaction revenue for a session.",
+        "calculation": "ga:transactionRevenue / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3360,7 +3697,8 @@
         "status": "PUBLIC",
         "uiName": "Shipping",
         "description": "The total cost of shipping.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3372,8 +3710,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Tax",
-        "description": "The total amount of tax.",
-        "allowedInSegments": "true"
+        "description": "Total tax for the transaction.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3385,8 +3724,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Total Value",
-        "description": "Total value for your property (including total revenue and total goal value).",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll)"
+        "description": "Total value for the property (including total revenue and total goal value).",
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3398,8 +3738,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Quantity",
-        "description": "The total number of items purchased. For example, if users purchase 2 frisbees and 5 tennis balls, 7 items have been purchased.",
-        "allowedInSegments": "true"
+        "description": "Total number of items purchased. For example, if users purchase 2 frisbees and 5 tennis balls, this will be 7.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3411,8 +3752,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Unique Purchases",
-        "description": "The number of product sets purchased. For example, if users purchase 2 frisbees and 5 tennis balls from your site, 2 unique products have been purchased.",
-        "allowedInSegments": "true"
+        "description": "The number of product sets purchased. For example, if users purchase 2 frisbees and 5 tennis balls from the site, this will be 2.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3425,7 +3767,8 @@
         "status": "PUBLIC",
         "uiName": "Average Price",
         "description": "The average revenue per item.",
-        "calculation": "ga:itemRevenue / ga:itemQuantity"
+        "calculation": "ga:itemRevenue / ga:itemQuantity",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3437,8 +3780,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Revenue",
-        "description": "The total revenue from purchased product items on your property.",
-        "allowedInSegments": "true"
+        "description": "The total revenue from purchased product items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3451,7 +3795,8 @@
         "status": "PUBLIC",
         "uiName": "Average QTY",
         "description": "The average quantity of this item (or group of items) sold per purchase.",
-        "calculation": "ga:itemQuantity / ga:uniquePurchases"
+        "calculation": "ga:itemQuantity / ga:uniquePurchases",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3463,7 +3808,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Revenue",
-        "description": "Transaction revenue in local currency."
+        "description": "Transaction revenue in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3475,7 +3821,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Shipping",
-        "description": "Transaction shipping cost in local currency."
+        "description": "Transaction shipping cost in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3487,7 +3834,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Tax",
-        "description": "Transaction tax in local currency."
+        "description": "Transaction tax in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3500,7 +3848,8 @@
         "status": "PUBLIC",
         "uiName": "Local Product Revenue",
         "description": "Product revenue in local currency.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3511,8 +3860,9 @@
         "dataType": "STRING",
         "group": "Social Interactions",
         "status": "PUBLIC",
-        "uiName": "Social Source",
-        "description": "For social interactions, a value representing the social network being tracked."
+        "uiName": "Social Network",
+        "description": "For social interactions, this represents the social network being tracked.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3524,7 +3874,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Action",
-        "description": "For social interactions, a value representing the social action being tracked (e.g. +1, bookmark)"
+        "description": "For social interactions, this is the social action (e.g., +1, bookmark) being tracked.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3535,8 +3886,9 @@
         "dataType": "STRING",
         "group": "Social Interactions",
         "status": "PUBLIC",
-        "uiName": "Social Source and Action",
-        "description": "For social interactions, a value representing the concatenation of the socialInteractionNetwork and socialInteractionAction action being tracked at this hit level (e.g. Google: +1)"
+        "uiName": "Social Network and Action",
+        "description": "For social interactions, this is the concatenation of the socialInteractionNetwork and socialInteractionAction action (e.g., Google: +1) being tracked at this hit level.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3548,7 +3900,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Entity",
-        "description": "For social interactions, a value representing the URL (or resource) which receives the social network action."
+        "description": "For social interactions, this is the URL (or resource) which receives the social network action.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3560,7 +3913,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Type",
-        "description": "Engagement type. Possible values are \"Socially Engaged\" or \"Not Socially Engaged\"."
+        "description": "Engagement type, either \"Socially Engaged\" or \"Not Socially Engaged\".",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3572,7 +3926,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Actions",
-        "description": "The total number of social interactions on your property."
+        "description": "The total number of social interactions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3584,7 +3939,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Unique Social Actions",
-        "description": "The number of sessions during which the specified social action(s) occurred at least once. This is based on the the unique combination of socialInteractionNetwork, socialInteractionAction, and socialInteractionTarget."
+        "description": "The number of sessions during which the specified social action(s) occurred at least once. This is based on the the unique combination of socialInteractionNetwork, socialInteractionAction, and socialInteractionTarget.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3596,8 +3952,9 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Actions Per Social Session",
-        "description": "The number of social interactions per session on your property.",
-        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions"
+        "description": "The number of social interactions per session.",
+        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3610,8 +3967,9 @@
         "group": "Social Interactions",
         "status": "DEPRECATED",
         "uiName": "Actions Per Social Session",
-        "description": "The number of social interactions per session on your property.",
-        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions"
+        "description": "The number of social interactions per session.",
+        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3623,8 +3981,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Timing Category",
-        "description": "A string for categorizing all user timing variables into logical groups for easier reporting purposes.",
-        "allowedInSegments": "true"
+        "description": "For easier reporting purposes, this is used to categorize all user timing variables into logical groups.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3637,7 +3996,8 @@
         "status": "PUBLIC",
         "uiName": "Timing Label",
         "description": "The name of the resource's action being tracked.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3649,8 +4009,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Timing Variable",
-        "description": "A value that can be used to add flexibility in visualizing user timings in the reports.",
-        "allowedInSegments": "true"
+        "description": "Used to add flexibility to visualize user timings in the reports.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3662,7 +4023,8 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "User Timing (ms)",
-        "description": "The total number of milliseconds for a user timing."
+        "description": "Total number of milliseconds for user timing.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3674,7 +4036,8 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "User Timing Sample",
-        "description": "The number of hits that were sent for a particular userTimingCategory, userTimingLabel, and userTimingVariable."
+        "description": "The number of hits sent for a particular userTimingCategory, userTimingLabel, or userTimingVariable.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3686,8 +4049,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Avg. User Timing (sec)",
-        "description": "The average amount of elapsed time.",
-        "calculation": "(ga:userTimingValue / ga:userTimingSample / 1000)"
+        "description": "The average elapsed time.",
+        "calculation": "(ga:userTimingValue / ga:userTimingSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3700,7 +4064,8 @@
         "status": "PUBLIC",
         "uiName": "Exception Description",
         "description": "The description for the exception.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3712,8 +4077,9 @@
         "group": "Exceptions",
         "status": "PUBLIC",
         "uiName": "Exceptions",
-        "description": "The number of exceptions that were sent to Google Analytics.",
-        "allowedInSegments": "true"
+        "description": "The number of exceptions sent to Google Analytics.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3726,7 +4092,8 @@
         "status": "PUBLIC",
         "uiName": "Exceptions / Screen",
         "description": "The number of exceptions thrown divided by the number of screenviews.",
-        "calculation": "ga:exceptions / ga:screenviews"
+        "calculation": "ga:exceptions / ga:screenviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3739,7 +4106,8 @@
         "status": "PUBLIC",
         "uiName": "Crashes",
         "description": "The number of exceptions where isFatal is set to true.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3752,7 +4120,8 @@
         "status": "PUBLIC",
         "uiName": "Crashes / Screen",
         "description": "The number of fatal exceptions thrown divided by the number of screenviews.",
-        "calculation": "ga:fatalExceptions / ga:screenviews"
+        "calculation": "ga:fatalExceptions / ga:screenviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3764,8 +4133,9 @@
         "group": "Content Experiments",
         "status": "PUBLIC",
         "uiName": "Experiment ID",
-        "description": "The user-scoped id of the content experiment that the user was exposed to when the metrics were reported.",
-        "allowedInSegments": "true"
+        "description": "The user-scoped ID of the content experiment that users were exposed to when the metrics were reported.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3776,9 +4146,10 @@
         "dataType": "STRING",
         "group": "Content Experiments",
         "status": "PUBLIC",
-        "uiName": "Variation",
-        "description": "The user-scoped id of the particular variation that the user was exposed to during a content experiment.",
-        "allowedInSegments": "true"
+        "uiName": "Variant",
+        "description": "The user-scoped ID of the particular variant that users were exposed to during a content experiment.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3790,12 +4161,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Logged  In (Custom Dimension 1)",
-        "description": "The name of the requested custom dimension, where XX refers the number/index of the custom dimension.",
+        "description": "The value of the requested custom dimension, where XX refers to the number or index of the custom dimension.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3807,12 +4179,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Breakpoint (Custom Dimension 2)",
-        "description": "The name of the requested custom dimension, where XX refers the number/index of the custom dimension.",
+        "description": "The value of the requested custom dimension, where XX refers to the number or index of the custom dimension.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3824,12 +4197,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Random (Custom Dimension 3)",
-        "description": "The name of the requested custom dimension, where XX refers the number/index of the custom dimension.",
+        "description": "The value of the requested custom dimension, where XX refers to the number or index of the custom dimension.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3846,7 +4220,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3863,7 +4238,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3880,7 +4256,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3897,7 +4274,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3914,7 +4292,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3926,12 +4305,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Queries  (success) (Custom Metric 1)",
-        "description": "The name of the requested custom metric, where XX refers the number/index of the custom metric.",
+        "description": "The value of the requested custom metric, where XX refers to the number or index of the custom metric. Note that the data type of ga:metricXX can be INTEGER, CURRENCY, or TIME.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3943,12 +4323,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Queries  (error) (Custom Metric 2)",
-        "description": "The name of the requested custom metric, where XX refers the number/index of the custom metric.",
+        "description": "The value of the requested custom metric, where XX refers to the number or index of the custom metric. Note that the data type of ga:metricXX can be INTEGER, CURRENCY, or TIME.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3960,12 +4341,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Monies (Custom Metric 3)",
-        "description": "The name of the requested custom metric, where XX refers the number/index of the custom metric.",
+        "description": "The value of the requested custom metric, where XX refers to the number or index of the custom metric. Note that the data type of ga:metricXX can be INTEGER, CURRENCY, or TIME.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3982,7 +4364,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3999,7 +4382,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4016,7 +4400,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4033,7 +4418,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4050,7 +4436,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4062,7 +4449,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Date",
-        "description": "The date of the session formatted as YYYYMMDD."
+        "description": "The date of the session formatted as YYYYMMDD.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4074,7 +4462,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Year",
-        "description": "The year of the session. A four-digit year from 2005 to the current year."
+        "description": "The year of the session, a four-digit year from 2005 to the current year.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4086,7 +4475,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month of the year",
-        "description": "The month of the session. A two digit integer from 01 to 12."
+        "description": "Month of the session, a two digit integer from 01 to 12.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4098,7 +4488,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week of the Year",
-        "description": "The week of the session. A two-digit number from 01 to 53. Each week starts on Sunday."
+        "description": "The week of the session, a two-digit number from 01 to 53. Each week starts on Sunday.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4110,7 +4501,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of the month",
-        "description": "The day of the month. A two-digit number from 01 to 31."
+        "description": "The day of the month, a two-digit number from 01 to 31.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4122,8 +4514,9 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour",
-        "description": "A two-digit hour of the day ranging from 00-23 in the timezone configured for the account. This value is also corrected for daylight savings time, adhering to all local rules for daylight savings time. If your timezone follows daylight savings time, there will be an apparent bump in the number of sessions during the change-over hour (e.g. between 1:00 and 2:00) for the day per year when that hour repeats. A corresponding hour with zero sessions will occur at the opposite changeover. (Google Analytics does not track user time more precisely than hours.)",
-        "allowedInSegments": "true"
+        "description": "A two-digit hour of the day ranging from 00-23 in the timezone configured for the account. This value is also corrected for daylight savings time. If the timezone follows daylight savings time, there will be an apparent bump in the number of sessions during the changeover hour (e.g., between 1:00 and 2:00) for the day per year when that hour repeats. A corresponding hour with zero sessions will occur at the opposite changeover. (Google Analytics does not track user time more precisely than hours.)",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4135,8 +4528,9 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Minute",
-        "description": "Returns the minute in the hour. The possible values are between 00 and 59.",
-        "allowedInSegments": "true"
+        "description": "Returns the minutes, between 00 and 59, in the hour.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4148,7 +4542,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month Index",
-        "description": "Index for each month in the specified date range. Index for the first month in the date range is 0, 1 for the second month, and so on. The index corresponds to month entries."
+        "description": "The index for a month in the specified date range. In the date range, the index for the first month is 0, for the second month 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4160,7 +4555,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week Index",
-        "description": "Index for each week in the specified date range. Index for the first week in the date range is 0, 1 for the second week, and so on. The index corresponds to week entries."
+        "description": "The index for each week in the specified date range. The index for the first week in the date range is 0, for the second week 1, and so on. The index corresponds to week entries.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4172,7 +4568,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day Index",
-        "description": "Index for each day in the specified date range. Index for the first day (i.e., start-date) in the date range is 0, 1 for the second day, and so on."
+        "description": "The index for each day in the specified date range. The index for the first day (i.e., start-date) in the date range is 0, for the second day 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4184,7 +4581,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Minute Index",
-        "description": "Index for each minute in the specified date range. Index for the first minute of first day (i.e., start-date) in the date range is 0, 1 for the next minute, and so on."
+        "description": "The index for each minute in the specified date range. The index for the first minute of the first day (i.e., start-date) in the date range is 0, for the next minute 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4196,7 +4594,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of Week",
-        "description": "The day of the week. A one-digit number from 0 (Sunday) to 6 (Saturday)."
+        "description": "Day of the week, a one-digit number from 0 (Sunday) to 6 (Saturday).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4208,7 +4607,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of Week Name",
-        "description": "The name of the day of the week (in English)."
+        "description": "Name (in English) of the day of the week.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4220,7 +4620,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour of Day",
-        "description": "Combined values of ga:date and ga:hour."
+        "description": "Combined values of ga:date and ga:hour.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4232,7 +4633,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month of Year",
-        "description": "Combined values of ga:year and ga:month."
+        "description": "Combined values of ga:year and ga:month.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4244,7 +4646,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week of Year",
-        "description": "Combined values of ga:year and ga:week."
+        "description": "Combined values of ga:year and ga:week.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4256,7 +4659,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Week of the Year",
-        "description": "The ISO week number, where each week starts with a Monday. Details: http://en.wikipedia.org/wiki/ISO_week_date. ga:isoWeek should only be used with ga:isoYear since ga:year represents gregorian calendar."
+        "description": "ISO week number, where each week starts on Monday. For details, see http://en.wikipedia.org/wiki/ISO_week_date. ga:isoWeek should only be used with ga:isoYear because ga:year represents Gregorian calendar.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4268,7 +4672,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Year",
-        "description": "The ISO year of the session. Details: http://en.wikipedia.org/wiki/ISO_week_date. ga:isoYear should only be used with ga:isoWeek since ga:week represents gregorian calendar."
+        "description": "The ISO year of the session. For details, see http://en.wikipedia.org/wiki/ISO_week_date. ga:isoYear should only be used with ga:isoWeek because ga:week represents Gregorian calendar.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4280,7 +4685,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Week of ISO Year",
-        "description": "Combined values of ga:isoYear and ga:isoWeek."
+        "description": "Combined values of ga:isoYear and ga:isoWeek.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4292,7 +4698,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad (GA Model)",
-        "description": "DCM ad name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4304,7 +4711,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad ID (GA Model)",
-        "description": "DCM ad ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4316,7 +4724,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type (GA Model)",
-        "description": "DCM ad type name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad type name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4328,7 +4737,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type ID",
-        "description": "DCM ad type ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad type ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4340,7 +4750,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser (GA Model)",
-        "description": "DCM advertiser name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM advertiser name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4352,7 +4763,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID (GA Model)",
-        "description": "DCM advertiser ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM advertiser ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4364,7 +4776,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign (GA Model)",
-        "description": "DCM campaign name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM campaign name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4376,7 +4789,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign ID (GA Model)",
-        "description": "DCM campaign ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM campaign ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4388,7 +4802,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative ID (GA Model)",
-        "description": "DCM creative ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4400,7 +4815,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative (GA Model)",
-        "description": "DCM creative name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4412,7 +4828,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Rendering ID (GA Model)",
-        "description": "DCM rendering ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM rendering ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4424,7 +4841,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type (GA Model)",
-        "description": "DCM creative type name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative type name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4436,7 +4854,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type ID (GA Model)",
-        "description": "DCM creative type ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative type ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4448,7 +4867,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Version (GA Model)",
-        "description": "DCM creative version of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative version of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4460,7 +4880,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site (GA Model)",
-        "description": "Site name where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only)."
+        "description": "Site name where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4472,7 +4893,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site ID (GA Model)",
-        "description": "DCM site ID where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site ID where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4484,7 +4906,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement (GA Model)",
-        "description": "DCM site placement name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site placement name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4496,7 +4919,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement ID (GA Model)",
-        "description": "DCM site placement ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site placement ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4508,7 +4932,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID (GA Model)",
-        "description": "DCM Floodlight configuration ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM Floodlight configuration ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4520,7 +4945,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity",
-        "description": "DCM Floodlight activity name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4532,7 +4958,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity and Group",
-        "description": "DCM Floodlight activity name and group name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity name and group name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4544,7 +4971,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity Group",
-        "description": "DCM Floodlight activity group name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity group name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4556,7 +4984,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity Group ID",
-        "description": "DCM Floodlight activity group ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity group ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4568,7 +4997,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity ID",
-        "description": "DCM Floodlight activity ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4580,7 +5010,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID",
-        "description": "DCM Floodlight advertiser ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight advertiser ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4592,7 +5023,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID",
-        "description": "DCM Floodlight configuration ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight configuration ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4604,7 +5036,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad",
-        "description": "DCM ad name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4616,7 +5049,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad ID (DFA Model)",
-        "description": "DCM ad ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4628,7 +5062,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type (DFA Model)",
-        "description": "DCM ad type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4640,7 +5075,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type ID (DFA Model)",
-        "description": "DCM ad type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4652,7 +5088,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser (DFA Model)",
-        "description": "DCM advertiser name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM advertiser name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4664,7 +5101,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID (DFA Model)",
-        "description": "DCM advertiser ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM advertiser ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4676,7 +5114,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Attribution Type (DFA Model)",
-        "description": "There are two possible values: ClickThrough and ViewThrough. If the last DCM event associated with the Google Analytics session was a click, then the value will be ClickThrough. If the last DCM event associated with the Google Analytics session was an ad impression, then the value will be ViewThrough (premium only)."
+        "description": "There are two possible values: ClickThrough and ViewThrough. If the last DCM event associated with the Google Analytics session was a click, then the value will be ClickThrough. If the last DCM event associated with the Google Analytics session was an ad impression, then the value will be ViewThrough (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4688,7 +5127,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign (DFA Model)",
-        "description": "DCM campaign name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM campaign name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4700,7 +5140,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign ID (DFA Model)",
-        "description": "DCM campaign ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM campaign ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4712,7 +5153,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative ID (DFA Model)",
-        "description": "DCM creative ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4724,7 +5166,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative (DFA Model)",
-        "description": "DCM creative name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4736,7 +5179,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Rendering ID (DFA Model)",
-        "description": "DCM rendering ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM rendering ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4748,7 +5192,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type (DFA Model)",
-        "description": "DCM creative type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4760,7 +5205,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type ID (DFA Model)",
-        "description": "DCM creative type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4772,7 +5218,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Version (DFA Model)",
-        "description": "DCM creative version of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative version of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4784,7 +5231,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site (DFA Model)",
-        "description": "Site name where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "Site name where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4796,7 +5244,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site ID (DFA Model)",
-        "description": "DCM site ID where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site ID where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4808,7 +5257,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement (DFA Model)",
-        "description": "DCM site placement name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site placement name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4820,7 +5270,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement ID (DFA Model)",
-        "description": "DCM site placement ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site placement ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4832,7 +5283,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID (DFA Model)",
-        "description": "DCM Floodlight configuration ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM Floodlight configuration ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4844,7 +5296,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Conversions",
-        "description": "The number of DCM Floodlight conversions (premium only)."
+        "description": "The number of DCM Floodlight conversions (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4856,7 +5309,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Revenue",
-        "description": "DCM Floodlight revenue (premium only)."
+        "description": "DCM Floodlight revenue (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4868,10 +5322,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 1",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4883,10 +5338,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 2",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4898,10 +5354,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 3",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4913,10 +5370,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 4",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4928,10 +5386,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group 5",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4946,7 +5405,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4961,7 +5421,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4976,7 +5437,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4991,7 +5453,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5006,7 +5469,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5018,10 +5482,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 1",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5033,10 +5498,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 2",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5048,10 +5514,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 3",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5063,10 +5530,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 4",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5078,10 +5546,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group 5",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5091,12 +5560,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 1",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5106,12 +5576,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 2",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5121,12 +5592,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 3",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5136,12 +5608,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 4",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5151,12 +5624,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group 5",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5168,8 +5642,8 @@
         "group": "Audience",
         "status": "PUBLIC",
         "uiName": "Age",
-        "description": "Age bracket of user.",
-        "allowedInSegments": "true"
+        "description": "Age bracket of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5182,8 +5656,8 @@
         "group": "Audience",
         "status": "DEPRECATED",
         "uiName": "Age",
-        "description": "Age bracket of user.",
-        "allowedInSegments": "true"
+        "description": "Age bracket of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5195,8 +5669,8 @@
         "group": "Audience",
         "status": "PUBLIC",
         "uiName": "Gender",
-        "description": "Gender of user.",
-        "allowedInSegments": "true"
+        "description": "Gender of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5209,8 +5683,8 @@
         "group": "Audience",
         "status": "DEPRECATED",
         "uiName": "Gender",
-        "description": "Gender of user.",
-        "allowedInSegments": "true"
+        "description": "Gender of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5223,7 +5697,7 @@
         "status": "PUBLIC",
         "uiName": "Other Category",
         "description": "Indicates that users are more likely to be interested in learning about the specified category, and more likely to be ready to purchase.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5236,7 +5710,7 @@
         "status": "PUBLIC",
         "uiName": "Affinity Category (reach)",
         "description": "Indicates that users are more likely to be interested in learning about the specified category.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5249,7 +5723,7 @@
         "status": "PUBLIC",
         "uiName": "In-Market Segment",
         "description": "Indicates that users are more likely to be ready to purchase products or services in the specified category.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5262,7 +5736,8 @@
         "status": "PUBLIC",
         "uiName": "AdSense Revenue",
         "description": "The total revenue from AdSense ads.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5274,8 +5749,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Ad Units Viewed",
-        "description": "The number of AdSense ad units viewed. An Ad unit is a set of ads displayed as a result of one piece of the AdSense ad code. Details: https://support.google.com/adsense/answer/32715?hl=en",
-        "allowedInSegments": "true"
+        "description": "The number of AdSense ad units viewed. An ad unit is a set of ads displayed as a result of one piece of the AdSense ad code. For details, see https://support.google.com/adsense/answer/32715?hl=en.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5287,8 +5763,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Impressions",
-        "description": "The number of AdSense ads viewed. Multiple ads can be displayed within an Ad Unit.",
-        "allowedInSegments": "true"
+        "description": "The number of AdSense ads viewed. Multiple ads can be displayed within an ad Unit.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5300,8 +5777,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Ads Clicked",
-        "description": "The number of times AdSense ads on your site were clicked.",
-        "allowedInSegments": "true"
+        "description": "The number of times AdSense ads on the site were clicked.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5313,8 +5791,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Page Impressions",
-        "description": "The number of pageviews during which an AdSense ad was displayed. A page impression can have multiple Ad Units.",
-        "allowedInSegments": "true"
+        "description": "The number of pageviews during which an AdSense ad was displayed. A page impression can have multiple ad Units.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5326,8 +5805,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense CTR",
-        "description": "The percentage of page impressions that resulted in a click on an AdSense ad.",
-        "calculation": "ga:adsenseAdsClicks/ga:adsensePageImpressions"
+        "description": "The percentage of page impressions resulted in a click on an AdSense ad.",
+        "calculation": "ga:adsenseAdsClicks/ga:adsensePageImpressions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5339,8 +5819,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense eCPM",
-        "description": "The estimated cost per thousand page impressions. It is your AdSense Revenue per 1000 page impressions.",
-        "calculation": "ga:adsenseRevenue/(ga:adsensePageImpressions/1000)"
+        "description": "The estimated cost per thousand page impressions. It is the AdSense Revenue per 1,000 page impressions.",
+        "calculation": "ga:adsenseRevenue/(ga:adsensePageImpressions/1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5352,8 +5833,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Exits",
-        "description": "The number of sessions that ended due to a user clicking on an AdSense ad.",
-        "allowedInSegments": "true"
+        "description": "The number of sessions ended due to a user clicking on an AdSense ad.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5365,7 +5847,8 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Viewable Impression %",
-        "description": "The percentage of impressions that were viewable."
+        "description": "The percentage of viewable impressions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5377,7 +5860,221 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Coverage",
-        "description": "The percentage of ad requests that returned at least one ad."
+        "description": "The percentage of ad requests that returned at least one ad.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxImpressions",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Impressions",
+        "description": "An Ad Exchange ad impression is reported whenever an individual ad is displayed on the website. For example, if a page with two ad units is viewed once, we'll display two impressions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxCoverage",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Coverage",
+        "description": "Coverage is the percentage of ad requests that returned at least one ad. Generally, coverage can help identify sites where the Ad Exchange account isn't able to provide targeted ads. (Ad Impressions / Total Ad Requests) * 100",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxMonetizedPageviews",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Monetized Pageviews",
+        "description": "This measures the total number of pageviews on the property that were shown with an ad from the linked Ad Exchange account. Note that a single page can have multiple ad units.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxImpressionsPerSession",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Impressions / Session",
+        "description": "The ratio of Ad Exchange ad impressions to Analytics sessions (Ad Impressions / Analytics Sessions).",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxViewableImpressionsPercent",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Viewable Impressions %",
+        "description": "The percentage of viewable ad impressions. An impression is considered a viewable impression when it has appeared within users' browsers and has the opportunity to be seen.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxClicks",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Clicks",
+        "description": "The number of times AdX ads were clicked on the site.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxCTR",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX CTR",
+        "description": "The percentage of pageviews that resulted in a click on an Ad Exchange ad.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxRevenue",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Revenue",
+        "description": "The total estimated revenue from Ad Exchange ads.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxRevenuePer1000Sessions",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Revenue / 1000 Sessions",
+        "description": "The total estimated revenue from Ad Exchange ads per 1,000 Analytics sessions. Note that this metric is based on sessions to the site, not on ad impressions.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxECPM",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX eCPM",
+        "description": "The effective cost per thousand pageviews. It is the Ad Exchange revenue per 1,000 pageviews.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:acquisitionCampaign",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Campaign",
+        "description": "The campaign through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionMedium",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Medium",
+        "description": "The medium through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionSource",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Source",
+        "description": "The source through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionSourceMedium",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Source / Medium",
+        "description": "The combined value of ga:userAcquisitionSource and ga:acquisitionMedium.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionTrafficChannel",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Channel",
+        "description": "Traffic channel through which users were acquired. It is extracted from users' first session. Traffic channel is computed based on the default channel grouping rules (at view level if available) at the time of user acquisition.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:browserSize",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Platform or Device",
+        "status": "PUBLIC",
+        "uiName": "Browser Size",
+        "description": "The viewport size of users' browsers. A session-scoped dimension, browser size captures the initial dimensions of the viewport in pixels and is formatted as width x height, for example, 1920x960.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5389,7 +6086,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Campaign Code",
-        "description": "When using manual campaign tracking, the value of the utm_id campaign tracking parameter."
+        "description": "For manual campaign tracking, it is the value of the utm_id campaign tracking parameter.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5401,8 +6099,9 @@
         "group": "Channel Grouping",
         "status": "PUBLIC",
         "uiName": "Default Channel Grouping",
-        "description": "The default channel grouping that is shared within the View (Profile).",
-        "allowedInSegments": "true"
+        "description": "The default channel grouping shared within the View (Profile).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5414,8 +6113,75 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Checkout Options",
-        "description": "User options specified during the checkout process, e.g., FedEx, DHL, UPS for delivery options or Visa, MasterCard, AmEx for payment options. This dimension should be used along with ga:shoppingStage (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "User options specified during the checkout process, e.g., FedEx, DHL, UPS for delivery options; Visa, MasterCard, AmEx for payment options. This dimension should be used with ga:shoppingStage (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cityId",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "City ID",
+        "description": "Users' city ID, derived from their IP addresses or Geographical IDs. The city IDs are the same as the Criteria IDs found at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cohort",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Cohort",
+        "description": "Name of the cohort to which a user belongs. Depending on how cohorts are defined, a user can belong to multiple cohorts, similar to how a user can belong to multiple segments.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthDay",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Day",
+        "description": "Day offset relative to the cohort definition date. For example, if a cohort is defined with the first visit date as 2015-09-01, then for the date 2015-09-04, ga:cohortNthDay will be 3.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthMonth",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Month",
+        "description": "Month offset relative to the cohort definition date. The semantics of this dimension differs based on whether lifetime value is requested or not. For a cohorts report not requesting lifetime value: This is the week offset from the cohort definition start date. For example, if cohort is defined as 2015-09-01 <= first session date <= 2015-09-30. Then, for 2015-09-01 <= date <= 2015-09-30, ga:cohortNthMonth = 0. 2015-10-01 <= date <= 2015-10-31, ga:cohortNthMonth = 2. and so on. For a cohorts request requesting lifetime value: ga:cohortNthMonth is calculated relative to the users acquisition date. It is not dependent on the cohort definition date. For example, if we define a cohort as 2015-10-01 <= first session date <= 2015-09-30. And a user was acquired on 2015-09-04. Then, for 2015-09-04 <= date <= 2015-10-04, ga:cohortNthMonth = 0 2015-10-04 <= date <= 2015-11-04, ga:cohortNthMonth = 1, and so on.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthWeek",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Week",
+        "description": "Week offset relative to the cohort definition date. The semantics of this dimension differs based on whether lifetime value is requested or not. For a cohorts report not requesting lifetime value: This is the week offset from the cohort definition start date. For example, if cohort is defined as 2015-09-01 <= first session date <= 2015-09-07. Then, for 2015-09-01 <= date <= 2015-09-07, ga:cohortNthWeek = 0. 2015-09-08 <= date <= 2015-09-14, ga:cohortNthWeek = 1. etc. For a cohorts request requesting lifetime value: ga:cohortNthWeek is calculated relative to the users acquisition date. It is not dependent on the cohort definition date. For example, if we define a cohort as 2015-09-01 <= first session date <= 2015-09-07. And a user was acquired on 2015-09-04. Then, for 2015-09-04 <= date<= 2015-09-10, ga:cohortNthWeek = 0 2015-09-11 <= date <= 2015-09-17, ga:cohortNthWeek = 1",
+        "addedInApiVersion": "4"
       }
     },
     {
@@ -5427,7 +6193,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Correlation Model ID",
-        "description": "Correlation Model ID for related products."
+        "description": "Correlation Model ID for related products.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:countryIsoCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Country ISO Code",
+        "description": "Users' country's ISO code (in ISO-3166-1 alpha-2 format), derived from their IP addresses or Geographical IDs. For example, BR for Brazil, CA for Canada.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:dataSource",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Platform or Device",
+        "status": "PUBLIC",
+        "uiName": "Data Source",
+        "description": "The data source of a hit. By default, hits sent from ga.js and analytics.js are reported as \"web\" and hits sent from the mobile SDKs are reported as \"app\". These values can be overridden in the Measurement Protocol.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5440,7 +6235,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Creative",
         "description": "The creative content designed for a promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5453,7 +6249,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion ID",
         "description": "The ID of the promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5466,7 +6263,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Name",
         "description": "The name of the promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5479,7 +6277,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Position",
         "description": "The position of the promotion on the web page or application screen (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5491,7 +6290,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "TrueView Video Ad",
-        "description": "'Yes' or 'No' - Indicates whether the ad is an AdWords TrueView video ad."
+        "description": "A boolean, Yes or No, indicating whether the ad is an AdWords TrueView video ad.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5503,7 +6303,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour Index",
-        "description": "Index for each hour in the specified date range. Index for the first hour of first day (i.e., start-date) in the date range is 0, 1 for the next hour, and so on."
+        "description": "The index for each hour in the specified date range. The index for the first hour of the first day (i.e., start-date) in the date range is 0, for the next hour 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5516,7 +6317,8 @@
         "status": "PUBLIC",
         "uiName": "Order Coupon Code",
         "description": "Code for the order-level coupon (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5529,7 +6331,8 @@
         "status": "PUBLIC",
         "uiName": "Product Brand",
         "description": "The brand name under which the product is sold (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5542,7 +6345,8 @@
         "status": "PUBLIC",
         "uiName": "Product Category (Enhanced Ecommerce)",
         "description": "The hierarchical category in which the product is classified (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5557,7 +6361,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5572,7 +6377,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5587,7 +6393,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5602,7 +6409,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5617,7 +6425,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5630,7 +6439,8 @@
         "status": "PUBLIC",
         "uiName": "Product Coupon Code",
         "description": "Code for the product-level coupon (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5643,7 +6453,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Name",
         "description": "The name of the product list in which the product appears (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5656,7 +6467,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Position",
         "description": "The position of the product in the product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5668,8 +6480,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Variant",
-        "description": "The specific variation of a product, e.g., XS, S, M, L for size or Red, Blue, Green, Black for color (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "The specific variation of a product, e.g., XS, S, M, L for size; or Red, Blue, Green, Black for color (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5681,7 +6494,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product ID",
-        "description": "ID of the product being queried."
+        "description": "ID of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5693,7 +6507,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Name",
-        "description": "Name of the product being queried."
+        "description": "Name of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5705,7 +6520,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Variation",
-        "description": "Variation of the product being queried."
+        "description": "Variation of the product being queried.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:regionId",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Region ID",
+        "description": "Users' region ID, derived from their IP addresses or Geographical IDs. In U.S., a region is a state, New York, for example. The region IDs are the same as the Criteria IDs listed at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:regionIsoCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Region ISO Code",
+        "description": "Users' region ISO code in ISO-3166-2 format, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5717,7 +6561,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product ID",
-        "description": "ID of the related product."
+        "description": "ID of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5729,7 +6574,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Name",
-        "description": "Name of the related product."
+        "description": "Name of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5741,7 +6587,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Variation",
-        "description": "Variation of the related product."
+        "description": "Variation of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5754,7 +6601,21 @@
         "status": "PUBLIC",
         "uiName": "Shopping Stage",
         "description": "Various stages of the shopping experience that users completed in a session, e.g., PRODUCT_VIEW, ADD_TO_CART, CHECKOUT, etc. (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:subContinentCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Sub Continent Code",
+        "description": "Users' sub-continent code in UN M.49 format, derived from their IP addresses or Geographical IDs. For example, 061 for Polynesia, 154 for Northern Europe.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5766,7 +6627,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Buy-to-Detail Rate",
-        "description": "Unique purchases divided by views of product detail pages (Enhanced Ecommerce)."
+        "description": "Unique purchases divided by views of product detail pages (Enhanced Ecommerce).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5778,7 +6640,229 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Cart-to-Detail Rate",
-        "description": "Product adds divided by views of product details (Enhanced Ecommerce)."
+        "description": "Product adds divided by views of product details (Enhanced Ecommerce).",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cohortActiveUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Users",
+        "description": "This metric is relevant in the context of ga:cohortNthDay/ga:cohortNthWeek/ga:cohortNthMonth. It indicates the number of users in the cohort who are active in the time window corresponding to the cohort nth day/week/month. For example, for ga:cohortNthWeek = 1, number of users (in the cohort) who are active in week 1. If a request doesn't have any of ga:cohortNthDay/ga:cohortNthWeek/ga:cohortNthMonth, this metric will have the same value as ga:cohortTotalUsers.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortAppviewsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Appviews per User",
+        "description": "App views per user for a cohort.",
+        "calculation": "ga:appviews / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortAppviewsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Appviews Per User (LTV)",
+        "description": "App views per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:appviews / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortGoalCompletionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Goal Completions per User",
+        "description": "Goal completions per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:goalCompletionsAll / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortGoalCompletionsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Goal Completions Per User (LTV)",
+        "description": "Goal completions per user for a cohort.",
+        "calculation": "ga:goalCompletionsAll / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortPageviewsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Pageviews per User",
+        "description": "Pageviews per user for a cohort.",
+        "calculation": "ga:pageviews / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortPageviewsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Pageviews Per User (LTV)",
+        "description": "Pageviews per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:pageviews / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRetentionRate",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "User Retention",
+        "description": "Cohort retention rate.",
+        "calculation": "ga:cohortActiveUsers / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRevenuePerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Revenue per User",
+        "description": "Revenue per user for a cohort.",
+        "calculation": "ga:transactions / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRevenuePerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Revenue Per User (LTV)",
+        "description": "Revenue per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:transactions / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionDurationPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "TIME",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Session Duration per User",
+        "description": "Session duration per user for a cohort.",
+        "calculation": "ga:sessionDuration / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionDurationPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "TIME",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Session Duration Per User (LTV)",
+        "description": "Session duration per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:sessionDuration / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Sessions per User",
+        "description": "Sessions per user for a cohort.",
+        "calculation": "ga:sessions / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Sessions Per User (LTV)",
+        "description": "Sessions per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:sessions / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortTotalUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Total Users",
+        "description": "Number of users belonging to the cohort, also known as cohort size.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortTotalUsersWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Users",
+        "description": "This is relevant in the context of a request which has the dimensions ga:acquisitionTrafficChannel/ga:acquisitionSource/ga:acquisitionMedium/ga:acquisitionCampaign. It represents the number of users in the cohorts who are acquired through the current channel/source/medium/campaign. For example, for ga:acquisitionTrafficChannel=Direct, it represents the number users in the cohort, who were acquired directly. If none of these mentioned dimensions are present, then its value is equal to ga:cohortTotalUsers.",
+        "addedInApiVersion": "4"
       }
     },
     {
@@ -5790,7 +6874,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Correlation Score",
-        "description": "Correlation Score for related products."
+        "description": "Correlation Score for related products.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5802,7 +6887,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA CPC",
-        "description": "DCM Cost Per Click (premium only)."
+        "description": "DCM Cost Per Click (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5814,7 +6900,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA CTR",
-        "description": "DCM Click Through Rate (premium only)."
+        "description": "DCM Click Through Rate (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5826,7 +6913,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Clicks",
-        "description": "DCM Total Clicks (premium only)."
+        "description": "DCM Total Clicks (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5838,7 +6926,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Cost",
-        "description": "DCM Total Cost (premium only)."
+        "description": "DCM Total Cost (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5850,7 +6939,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Impressions",
-        "description": "DCM Total Impressions (premium only)."
+        "description": "DCM Total Impressions (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5860,9 +6950,23 @@
         "type": "METRIC",
         "dataType": "PERCENT",
         "group": "DoubleClick Campaign Manager",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "DFA Margin",
-        "description": "DCM Margin (premium only)."
+        "description": "This metric is deprecated and will be removed soon. Please use ga:dcmROAS instead.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:dcmROAS",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "DoubleClick Campaign Manager",
+        "status": "PUBLIC",
+        "uiName": "DFA ROAS",
+        "description": "DCM Return On Ad Spend (ROAS) (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5872,9 +6976,10 @@
         "type": "METRIC",
         "dataType": "PERCENT",
         "group": "DoubleClick Campaign Manager",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "DFA ROI",
-        "description": "DCM Return On Investment (premium only)."
+        "description": "This metric is deprecated and will be removed soon. Please use ga:dcmROAS instead.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5886,7 +6991,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA RPC",
-        "description": "DCM Revenue Per Click (premium only)."
+        "description": "DCM Revenue Per Click (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5898,8 +7004,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Hits",
-        "description": "Total number of hits sent to Google Analytics. This metric sums all hit types (e.g. pageview, event, timing, etc.).",
-        "allowedInSegments": "true"
+        "description": "Total number of hits for the view (profile). This metric sums all hit types, including pageview, custom event, ecommerce, and other types. Because this metric is based on the view (profile), not on the property, it is not the same as the property's hit volume.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5912,7 +7019,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion CTR",
         "description": "The rate at which users clicked through to view the internal promotion (ga:internalPromotionClicks / ga:internalPromotionViews) - (Enhanced Ecommerce).",
-        "calculation": "ga:internalPromotionClicks / ga:internalPromotionViews"
+        "calculation": "ga:internalPromotionClicks / ga:internalPromotionViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5925,7 +7033,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Clicks",
         "description": "The number of clicks on an internal promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5938,7 +7047,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Views",
         "description": "The number of views of an internal promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5950,8 +7060,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Product Refund Amount",
-        "description": "Refund amount for a given product in the local currency (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Refund amount in local currency for a given product (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5963,8 +7074,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Refund Amount",
-        "description": "Total refund amount for the transaction in the local currency (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Total refund amount in local currency for the transaction (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5977,7 +7089,8 @@
         "status": "PUBLIC",
         "uiName": "Product Adds To Cart",
         "description": "Number of times the product was added to the shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5990,7 +7103,8 @@
         "status": "PUBLIC",
         "uiName": "Product Checkouts",
         "description": "Number of times the product was included in the check-out process (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6003,7 +7117,8 @@
         "status": "PUBLIC",
         "uiName": "Product Detail Views",
         "description": "Number of times users viewed the product-detail page (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6016,7 +7131,8 @@
         "status": "PUBLIC",
         "uiName": "Product List CTR",
         "description": "The rate at which users clicked through on the product in a product list (ga:productListClicks / ga:productListViews) - (Enhanced Ecommerce).",
-        "calculation": "ga:productListClicks / ga:productListViews"
+        "calculation": "ga:productListClicks / ga:productListViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6029,7 +7145,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Clicks",
         "description": "Number of times users clicked the product when it appeared in the product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6042,7 +7159,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Views",
         "description": "Number of times the product appeared in a product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6055,7 +7173,8 @@
         "status": "PUBLIC",
         "uiName": "Product Refund Amount",
         "description": "Total refund amount associated with the product (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6068,7 +7187,8 @@
         "status": "PUBLIC",
         "uiName": "Product Refunds",
         "description": "Number of times a refund was issued for the product (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6080,8 +7200,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Removes From Cart",
-        "description": "Number of times the product was removed from shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Number of times the product was removed from the shopping cart (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6094,7 +7215,8 @@
         "status": "PUBLIC",
         "uiName": "Product Revenue per Purchase",
         "description": "Average product revenue per purchase (commonly used with Product Coupon Code) (ga:itemRevenue / ga:uniquePurchases) - (Enhanced Ecommerce).",
-        "calculation": "ga:itemRevenue / ga:uniquePurchases"
+        "calculation": "ga:itemRevenue / ga:uniquePurchases",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6107,7 +7229,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Added To Cart",
         "description": "Number of product units added to the shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6120,7 +7243,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Checked Out",
         "description": "Number of product units included in check out (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6133,7 +7257,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Refunded",
         "description": "Number of product units refunded (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6145,8 +7270,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Quantity Removed From Cart",
-        "description": "Number of product units removed from cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Number of product units removed from a shopping cart (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6158,7 +7284,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Quantity",
-        "description": "Quantity of the product being queried."
+        "description": "Quantity of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6171,7 +7298,8 @@
         "status": "PUBLIC",
         "uiName": "Refund Amount",
         "description": "Currency amount refunded for a transaction (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6183,7 +7311,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Quantity",
-        "description": "Quantity of the related product."
+        "description": "Quantity of the related product.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:revenuePerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ecommerce",
+        "status": "PUBLIC",
+        "uiName": "Revenue per User",
+        "description": "The total sale revenue (excluding shipping and tax) of the transaction divided by the total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:sessionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "Number of Sessions per User",
+        "description": "The total number of sessions divided by the total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -6196,7 +7353,22 @@
         "status": "PUBLIC",
         "uiName": "Refunds",
         "description": "Number of refunds that have been issued (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:transactionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Ecommerce",
+        "status": "PUBLIC",
+        "uiName": "Transactions per User",
+        "description": "Total number of transactions divided by total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     }
   ]

--- a/test/_fixtures/metadata.json
+++ b/test/_fixtures/metadata.json
@@ -1,7 +1,7 @@
 {
   "kind": "analytics#columns",
-  "etag": "\"gUXd2oJOIvAWr2KnYegR9N0sJ7c/Duhub3vzRGEQ1SK4h3jlmcENHac\"",
-  "totalResults": 424,
+  "etag": "\"RTuqIyS1Tt5XEFy6I77L5pEAbZQ/lwy4jM_fkWuurrzNQQUx_Pg44Yc\"",
+  "totalResults": 476,
   "attributeNames": [
     "replacedBy",
     "type",
@@ -16,7 +16,8 @@
     "maxTemplateIndex",
     "premiumMinTemplateIndex",
     "premiumMaxTemplateIndex",
-    "allowedInSegments"
+    "allowedInSegments",
+    "addedInApiVersion"
   ],
   "items": [
     {
@@ -28,8 +29,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "User Type",
-        "description": "A boolean indicating if a user is new or returning. Possible values: New Visitor, Returning Visitor.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either New Visitor or Returning Visitor, indicating if the users are new or returning.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -42,8 +44,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "User Type",
-        "description": "A boolean indicating if a user is new or returning. Possible values: New Visitor, Returning Visitor.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either New Visitor or Returning Visitor, indicating if the users are new or returning.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -55,8 +58,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Count of Sessions",
-        "description": "The session index for a user to your property. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indicies. For example, if a certain user has 4 sessions to your website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
-        "allowedInSegments": "true"
+        "description": "The session index for a user. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indices. For example, if a user has 4 sessions to the website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -69,8 +73,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Count of Sessions",
-        "description": "The session index for a user to your property. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indicies. For example, if a certain user has 4 sessions to your website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
-        "allowedInSegments": "true"
+        "description": "The session index for a user. Each session from a unique user will get its own incremental index starting from 1 for the first session. Subsequent sessions do not change previous session indices. For example, if a user has 4 sessions to the website, sessionCount for that user will have 4 distinct values of '1' through '4'.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -82,8 +87,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Days Since Last Session",
-        "description": "The number of days elapsed since users last visited your property. Used to calculate user loyalty.",
-        "allowedInSegments": "true"
+        "description": "The number of days elapsed since users last visited the property, used to calculate user loyalty.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -96,8 +102,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Days Since Last Session",
-        "description": "The number of days elapsed since users last visited your property. Used to calculate user loyalty.",
-        "allowedInSegments": "true"
+        "description": "The number of days elapsed since users last visited the property, used to calculate user loyalty.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -109,8 +116,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "User Defined Value",
-        "description": "The value provided when you define custom user segments for your property.",
-        "allowedInSegments": "true"
+        "description": "The value provided when defining custom user segments for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -122,7 +130,8 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "Users",
-        "description": "Total number of users to your property for the requested time period."
+        "description": "The total number of users for the requested time period.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -135,7 +144,8 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "Users",
-        "description": "Total number of users to your property for the requested time period."
+        "description": "The total number of users for the requested time period.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -147,8 +157,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "New Users",
-        "description": "The number of users whose session on your property was marked as a first-time session.",
-        "allowedInSegments": "true"
+        "description": "The number of users whose session was marked as a first-time session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -161,8 +172,9 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "New Users",
-        "description": "The number of users whose session on your property was marked as a first-time session.",
-        "allowedInSegments": "true"
+        "description": "The number of users whose session was marked as a first-time session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -174,8 +186,9 @@
         "group": "User",
         "status": "PUBLIC",
         "uiName": "% New Sessions",
-        "description": "The percentage of sessions by people who had never visited your property before.",
-        "calculation": "ga:newUsers / ga:sessions"
+        "description": "The percentage of sessions by users who had never visited the property before.",
+        "calculation": "ga:newUsers / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -188,8 +201,61 @@
         "group": "User",
         "status": "DEPRECATED",
         "uiName": "% New Sessions",
-        "description": "The percentage of sessions by people who had never visited your property before.",
-        "calculation": "ga:newUsers / ga:sessions"
+        "description": "The percentage of sessions by users who had never visited the property before.",
+        "calculation": "ga:newUsers / ga:sessions",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:1dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "1 Day Active Users",
+        "description": "Total number of 1-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 1-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:7dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "7 Day Active Users",
+        "description": "Total number of 7-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 7-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:14dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "14 Day Active Users",
+        "description": "Total number of 14-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 14-day period ending on the given date.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:30dayUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "30 Day Active Users",
+        "description": "Total number of 30-day active users for each day in the requested time period. At least one of ga:nthDay, ga:date, or ga:day must be specified as a dimension to query this metric. For a given date, the returned value will be the total number of unique users for the 30-day period ending on the given date.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -201,8 +267,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Session Duration",
-        "description": "The length of a session on your property measured in seconds and reported in second increments. The value returned is a string.",
-        "allowedInSegments": "true"
+        "description": "The length (returned as a string) of a session measured in seconds and reported in second increments.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -215,8 +282,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Session Duration",
-        "description": "The length of a session on your property measured in seconds and reported in second increments. The value returned is a string.",
-        "allowedInSegments": "true"
+        "description": "The length (returned as a string) of a session measured in seconds and reported in second increments.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -228,8 +296,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Sessions",
-        "description": "Counts the total number of sessions.",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -242,8 +311,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Sessions",
-        "description": "Counts the total number of sessions.",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -255,8 +325,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Bounces",
-        "description": "The total number of single page (or single engagement hit) sessions for your property.",
-        "allowedInSegments": "true"
+        "description": "The total number of single page (or single engagement hit) sessions for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -270,7 +341,8 @@
         "status": "DEPRECATED",
         "uiName": "Bounce Rate",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:bounceRate instead.",
-        "calculation": "ga:bounces / ga:entrances"
+        "calculation": "ga:bounces / ga:entrances",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -282,8 +354,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Bounce Rate",
-        "description": "The percentage of single-page session (i.e., session in which the person left your property from the first page).",
-        "calculation": "ga:bounces / ga:sessions"
+        "description": "The percentage of single-page session (i.e., session in which the person left the property from the first page).",
+        "calculation": "ga:bounces / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -296,8 +369,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Bounce Rate",
-        "description": "The percentage of single-page session (i.e., session in which the person left your property from the first page).",
-        "calculation": "ga:bounces / ga:sessions"
+        "description": "The percentage of single-page session (i.e., session in which the person left the property from the first page).",
+        "calculation": "ga:bounces / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -309,8 +383,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Session Duration",
-        "description": "The total duration of user sessions represented in total seconds.",
-        "allowedInSegments": "true"
+        "description": "Total duration (in seconds) of users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -323,8 +398,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Session Duration",
-        "description": "The total duration of user sessions represented in total seconds.",
-        "allowedInSegments": "true"
+        "description": "Total duration (in seconds) of users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -336,8 +412,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Avg. Session Duration",
-        "description": "The average duration of user sessions represented in total seconds.",
-        "calculation": "ga:sessionDuration / ga:sessions"
+        "description": "The average duration (in seconds) of users' sessions.",
+        "calculation": "ga:sessionDuration / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -350,8 +427,9 @@
         "group": "Session",
         "status": "DEPRECATED",
         "uiName": "Avg. Session Duration",
-        "description": "The average duration of user sessions represented in total seconds.",
-        "calculation": "ga:sessionDuration / ga:sessions"
+        "description": "The average duration (in seconds) of users' sessions.",
+        "calculation": "ga:sessionDuration / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -363,8 +441,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Referral Path",
-        "description": "The path of the referring URL (e.g. document.referrer). If someone places a link to your property on their website, this element contains the path of the page that contains the referring link.",
-        "allowedInSegments": "true"
+        "description": "The path of the referring URL (e.g., document.referrer). If someone places on their webpage a link to the property, this is the path of the page containing the referring link.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -376,7 +455,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Full Referrer",
-        "description": "The full referring URL including the hostname and path."
+        "description": "The full referring URL including the hostname and path.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -388,8 +468,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Campaign",
-        "description": "When using manual campaign tracking, the value of the utm_campaign campaign tracking parameter. When using AdWords autotagging, the name(s) of the online ad campaign that you use for your property. Otherwise the value (not set) is used.",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_campaign campaign tracking parameter. For AdWords autotagging, it is the name(s) of the online ad campaign(s) you use for the property. If you use neither, its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -401,8 +482,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Source",
-        "description": "The source of referrals to your property. When using manual campaign tracking, the value of the utm_source campaign tracking parameter. When using AdWords autotagging, the value is google. Otherwise the domain of the source referring the user to your property (e.g. document.referrer). The value may also contain a port address. If the user arrived without a referrer, the value is (direct)",
-        "allowedInSegments": "true"
+        "description": "The source of referrals. For manual campaign tracking, it is the value of the utm_source campaign tracking parameter. For AdWords autotagging, it is google. If you use neither, it is the domain of the source (e.g., document.referrer) referring the users. It may also contain a port address. If users arrived without a referrer, its value is (direct).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -414,8 +496,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Medium",
-        "description": "The type of referrals to your property. When using manual campaign tracking, the value of the utm_medium campaign tracking parameter. When using AdWords autotagging, the value is ppc. If the user comes from a search engine detected by Google Analytics, the value is organic. If the referrer is not a search engine, the value is referral. If the users came directly to the property, and document.referrer is empty, the value is (none).",
-        "allowedInSegments": "true"
+        "description": "The type of referrals. For manual campaign tracking, it is the value of the utm_medium campaign tracking parameter. For AdWords autotagging, it is ppc. If users came from a search engine detected by Google Analytics, it is organic. If the referrer is not a search engine, it is referral. If users came directly to the property and document.referrer is empty, its value is (none).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -428,7 +511,8 @@
         "status": "PUBLIC",
         "uiName": "Source / Medium",
         "description": "Combined values of ga:source and ga:medium.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -440,8 +524,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Keyword",
-        "description": "When using manual campaign tracking, the value of the utm_term campaign tracking parameter. When using AdWords autotagging or if a user used organic search to reach your property, the keywords used by users to reach your property. Otherwise the value is (not set).",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_term campaign tracking parameter. For AdWords autotagging or when users use organic search to reach the property, it contains the keywords used to reach the property. Otherwise its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -453,8 +538,9 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Ad Content",
-        "description": "When using manual campaign tracking, the value of the utm_content campaign tracking parameter. When using AdWords autotagging, the first line of the text for your online Ad campaign. If you are using mad libs for your AdWords content, this field displays the keywords you provided for the mad libs keyword match. Otherwise the value is (not set)",
-        "allowedInSegments": "true"
+        "description": "For manual campaign tracking, it is the value of the utm_campaign campaign tracking parameter. For AdWords autotagging, it is the first line of the text for the online Ad campaign. If you use mad libs for the AdWords content, it contains the keywords you provided for the mad libs keyword match. If you use none of the above, its value is (not set).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -466,7 +552,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Social Network",
-        "description": "Name of the social network. This can be related to the referring social network for traffic sources, or to the social network for social data hub activities. E.g. Google+, Blogger, etc."
+        "description": "The social network name. This can be related to the referring social network for traffic sources, or to the social network for social data hub activities; e.g., Google+, Blogger.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -478,7 +565,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Social Source Referral",
-        "description": "Indicates sessions that arrived to the property from a social source. The possible values are Yes or No where the first letter is capitalized."
+        "description": "A boolean, either Yes or No, indicates whether sessions to the property are from a social source.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -490,7 +578,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Organic Searches",
-        "description": "The number of organic searches that happened within a session. This metric is search engine agnostic."
+        "description": "The number of organic searches happened in a session. This metric is search engine agnostic.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -502,8 +591,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Group",
-        "description": "The name of your AdWords ad group.",
-        "allowedInSegments": "true"
+        "description": "The name of the AdWords ad group.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -515,8 +605,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Slot",
-        "description": "The location of the advertisement on the hosting page (Top, RHS, or not set).",
-        "allowedInSegments": "true"
+        "description": "The location (Top, RHS, or not set) of the advertisement on the hosting page.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -526,10 +617,11 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Adwords",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Ad Slot Position",
-        "description": "The ad slot positions in which your AdWords ads appeared (1-8).",
-        "allowedInSegments": "true"
+        "description": "This dimension is deprecated and will soon be removed.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -541,7 +633,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Distribution Network",
-        "description": "The networks used to deliver your ads (Content, Search, Search partners, etc.)."
+        "description": "The network (Content, Search, Search partners, etc.) used to deliver the ads.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -553,7 +646,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Query Match Type",
-        "description": "The match types applied for the search term the user had input(Phrase, Exact, Broad, etc.). Ads on the content network are identified as \"Content network\". Details: https://support.google.com/adwords/answer/2472708?hl=en"
+        "description": "The match type (Phrase, Exact, Broad, etc.) applied for users' search term. Ads on the content network are identified as \"Content network\". For details, see https://support.google.com/adwords/answer/2472708?hl=en.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -565,7 +659,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Keyword Match Type",
-        "description": "The match types applied to your keywords (Phrase, Exact, Broad). Details: https://support.google.com/adwords/answer/2472708?hl=en"
+        "description": "The match type (Phrase, Exact, or Broad) applied to the keywords. For details, see https://support.google.com/adwords/answer/2472708.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -577,7 +672,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Matched Search Query",
-        "description": "The search queries that triggered impressions of your AdWords ads."
+        "description": "The search query that triggered impressions of the AdWords ads.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -589,7 +685,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement Domain",
-        "description": "The domains where your ads on the content network were placed."
+        "description": "The domain where the ads on the content network were placed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -601,7 +698,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement URL",
-        "description": "The URLs where your ads on the content network were placed."
+        "description": "The URL where the ads were placed on the content network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -613,7 +711,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Ad Format",
-        "description": "Your AdWords ad formats (Text, Image, Flash, Video, etc.)."
+        "description": "The AdWords ad format (Text, Image, Flash, Video, etc.).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -625,7 +724,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Targeting Type",
-        "description": "How your AdWords ads were targeted (keyword, placement, and vertical targeting, etc.)."
+        "description": "This (keyword, placement, or vertical targeting) indicates how the AdWords ads were targeted.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -637,7 +738,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Placement Type",
-        "description": "How you manage your ads on the content network. Values are Automatic placements or Managed placements."
+        "description": "It is Automatic placements or Managed placements, indicating how the ads were managed on the content network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -649,7 +751,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Display URL",
-        "description": "The URLs your AdWords ads displayed."
+        "description": "The URL the AdWords ads displayed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -661,7 +764,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Destination URL",
-        "description": "The URLs to which your AdWords ads referred traffic."
+        "description": "The URL to which the AdWords ads referred traffic.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -673,7 +777,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Customer ID",
-        "description": "A string. Corresponds to AdWords API AccountInfo.customerId."
+        "description": "Customer's AdWords ID, corresponding to AdWords API AccountInfo.customerId.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -685,7 +790,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Campaign ID",
-        "description": "A string. Corresponds to AdWords API Campaign.id."
+        "description": "AdWords API Campaign.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -697,7 +803,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Ad Group ID",
-        "description": "A string. Corresponds to AdWords API AdGroup.id."
+        "description": "AdWords API AdGroup.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -709,7 +816,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Creative ID",
-        "description": "A string. Corresponds to AdWords API Ad.id."
+        "description": "AdWords API Ad.id.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -721,7 +829,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "AdWords Criteria ID",
-        "description": "A string. Corresponds to AdWords API Criterion.id."
+        "description": "AdWords API Criterion.id. The geographical targeting Criteria IDs are listed at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -733,7 +842,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Impressions",
-        "description": "Total number of campaign impressions."
+        "description": "Total number of campaign impressions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -745,7 +855,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Clicks",
-        "description": "The total number of times users have clicked on an ad to reach your property."
+        "description": "Total number of times users have clicked on an ad to reach the property.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -757,7 +868,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost",
-        "description": "Derived cost for the advertising campaign. The currency for this value is based on the currency that you set in your AdWords account."
+        "description": "Derived cost for the advertising campaign. Its currency is the one you set in the AdWords account.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -770,7 +882,8 @@
         "status": "PUBLIC",
         "uiName": "CPM",
         "description": "Cost per thousand impressions.",
-        "calculation": "ga:adCost / (ga:impressions / 1000)"
+        "calculation": "ga:adCost / (ga:impressions / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -783,7 +896,8 @@
         "status": "PUBLIC",
         "uiName": "CPC",
         "description": "Cost to advertiser per click.",
-        "calculation": "ga:adCost / ga:adClicks"
+        "calculation": "ga:adCost / ga:adClicks",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -795,8 +909,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "CTR",
-        "description": "Click-through-rate for your ad. This is equal to the number of clicks divided by the number of impressions for your ad (e.g. how many times users clicked on one of your ads where that ad appeared).",
-        "calculation": "ga:adClicks / ga:impressions"
+        "description": "Click-through-rate for the ad. This is equal to the number of clicks divided by the number of impressions for the ad (e.g., how many times users clicked on one of the ads where that ad appeared).",
+        "calculation": "ga:adClicks / ga:impressions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -808,8 +923,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Transaction",
-        "description": "The cost per transaction for your property.",
-        "calculation": "(ga:adCost) / (ga:transactions)"
+        "description": "The cost per transaction for the property.",
+        "calculation": "(ga:adCost) / (ga:transactions)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -821,8 +937,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Goal Conversion",
-        "description": "The cost per goal conversion for your property.",
-        "calculation": "(ga:adCost) / (ga:goalCompletionsAll)"
+        "description": "The cost per goal conversion for the property.",
+        "calculation": "(ga:adCost) / (ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -834,8 +951,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "Cost per Conversion",
-        "description": "The cost per conversion (including ecommerce and goal conversions) for your property.",
-        "calculation": "(ga:adCost) / (ga:transactions  +  ga:goalCompletionsAll)"
+        "description": "The cost per conversion (including ecommerce and goal conversions) for the property.",
+        "calculation": "(ga:adCost) / (ga:transactions  +  ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -847,8 +965,9 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "RPC",
-        "description": "RPC or revenue-per-click is the average revenue (from ecommerce sales and/or goal value) you received for each click on one of your search ads.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adClicks"
+        "description": "RPC or revenue-per-click, the average revenue (from ecommerce sales and/or goal value) you received for each click on one of the search ads.",
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adClicks",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -861,7 +980,8 @@
         "status": "DEPRECATED",
         "uiName": "ROI",
         "description": "This metric is deprecated and will be removed soon. Please use ga:ROAS instead.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / ga:adCost"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / ga:adCost",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -874,7 +994,8 @@
         "status": "DEPRECATED",
         "uiName": "Margin",
         "description": "This metric is deprecated and will be removed soon. Please use ga:ROAS instead.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / (ga:transactionRevenue + ga:goalValueAll)"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll - ga:adCost) / (ga:transactionRevenue + ga:goalValueAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -887,7 +1008,21 @@
         "status": "PUBLIC",
         "uiName": "ROAS",
         "description": "Return On Ad Spend (ROAS) is the total transaction revenue and goal value divided by derived advertising cost.",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adCost"
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll) / ga:adCost",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adQueryWordCount",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Adwords",
+        "status": "PUBLIC",
+        "uiName": "Query Word Count",
+        "description": "The number of words in the search query.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -899,7 +1034,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Completion Location",
-        "description": "The page path or screen name that matched any destination type goal completion."
+        "description": "The page path or screen name that matched any destination type goal completion.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -911,7 +1047,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 1",
-        "description": "The page path or screen name that matched any destination type goal, one step prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, one step prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -923,7 +1060,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 2",
-        "description": "The page path or screen name that matched any destination type goal, two steps prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, two steps prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -935,7 +1073,8 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Previous Step - 3",
-        "description": "The page path or screen name that matched any destination type goal, three steps prior to the goal completion location."
+        "description": "The page path or screen name that matched any destination type goal, three steps prior to the goal completion location.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -950,7 +1089,8 @@
         "description": "The total number of starts for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -962,8 +1102,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Starts",
-        "description": "The total number of starts for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total number of starts for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -978,7 +1119,8 @@
         "description": "The total number of completions for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -990,8 +1132,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Completions",
-        "description": "The total number of completions for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total number of completions for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1006,7 +1149,8 @@
         "description": "The total numeric value for the requested goal number.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1018,8 +1162,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Value",
-        "description": "The total numeric value for all goals defined for your profile.",
-        "allowedInSegments": "true"
+        "description": "Total numeric value for all goals defined in the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1031,8 +1176,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Per Session Goal Value",
-        "description": "The average goal value of a session on your property.",
-        "calculation": "ga:goalValueAll / ga:sessions"
+        "description": "The average goal value of a session.",
+        "calculation": "ga:goalValueAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1045,8 +1191,9 @@
         "group": "Goal Conversions",
         "status": "DEPRECATED",
         "uiName": "Per Session Goal Value",
-        "description": "The average goal value of a session on your property.",
-        "calculation": "ga:goalValueAll / ga:sessions"
+        "description": "The average goal value of a session.",
+        "calculation": "ga:goalValueAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1058,10 +1205,11 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal XX Conversion Rate",
-        "description": "The percentage of sessions which resulted in a conversion to the requested goal number.",
+        "description": "Percentage of sessions resulting in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:sessions",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1073,8 +1221,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Goal Conversion Rate",
-        "description": "The percentage of sessions which resulted in a conversion to at least one of your goals.",
-        "calculation": "ga:goalCompletionsAll / ga:sessions"
+        "description": "The percentage of sessions which resulted in a conversion to at least one of the goals.",
+        "calculation": "ga:goalCompletionsAll / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1089,7 +1238,8 @@
         "description": "The number of times users started conversion activity on the requested goal number without actually completing it.",
         "calculation": "(ga:goalXXStarts - ga:goalXXCompletions)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1102,7 +1252,8 @@
         "status": "PUBLIC",
         "uiName": "Abandoned Funnels",
         "description": "The overall number of times users started goals without actually completing them.",
-        "calculation": "(ga:goalStartsAll - ga:goalCompletionsAll)"
+        "calculation": "(ga:goalStartsAll - ga:goalCompletionsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1117,7 +1268,8 @@
         "description": "The rate at which the requested goal number was abandoned.",
         "calculation": "((ga:goalXXStarts - ga:goalXXCompletions)) / (ga:goalXXStarts)",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1129,8 +1281,9 @@
         "group": "Goal Conversions",
         "status": "PUBLIC",
         "uiName": "Total Abandonment Rate",
-        "description": "The rate at which goals were abandoned.",
-        "calculation": "((ga:goalStartsAll - ga:goalCompletionsAll)) / (ga:goalStartsAll)"
+        "description": "Goal abandonment rate.",
+        "calculation": "((ga:goalStartsAll - ga:goalCompletionsAll)) / (ga:goalStartsAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1142,8 +1295,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Browser",
-        "description": "The names of browsers used by users to your website. For example, Internet Explorer or Firefox.",
-        "allowedInSegments": "true"
+        "description": "The name of users' browsers, for example, Internet Explorer or Firefox.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1155,8 +1309,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Browser Version",
-        "description": "The browser versions used by users to your website. For example, 2.0.0.14",
-        "allowedInSegments": "true"
+        "description": "The version of users' browsers, for example, 2.0.0.14.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1168,8 +1323,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Operating System",
-        "description": "The operating system used by your users. For example, Windows, Linux , Macintosh, iPhone, iPod.",
-        "allowedInSegments": "true"
+        "description": "Users' operating system, for example, Windows, Linux, Macintosh, or iOS.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1181,8 +1337,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Operating System Version",
-        "description": "The version of the operating system used by your users, such as XP for Windows or PPC for Macintosh.",
-        "allowedInSegments": "true"
+        "description": "The version of users' operating system, i.e., XP for Windows, PPC for Macintosh.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1195,7 +1352,8 @@
         "status": "DEPRECATED",
         "uiName": "Mobile (Including Tablet)",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:deviceCategory instead (e.g., ga:deviceCategory==mobile).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1208,7 +1366,8 @@
         "status": "DEPRECATED",
         "uiName": "Tablet",
         "description": "This dimension is deprecated and will be removed soon. Please use ga:deviceCategory instead (e.g., ga:deviceCategory==tablet).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1221,7 +1380,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Branding",
         "description": "Mobile manufacturer or branded name.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1233,8 +1393,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Mobile Device Model",
-        "description": "Mobile device model",
-        "allowedInSegments": "true"
+        "description": "Mobile device model.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1246,8 +1407,9 @@
         "group": "Platform or Device",
         "status": "PUBLIC",
         "uiName": "Mobile Input Selector",
-        "description": "Selector used on the mobile device (e.g.: touchscreen, joystick, clickwheel, stylus).",
-        "allowedInSegments": "true"
+        "description": "Selector (e.g., touchscreen, joystick, clickwheel, stylus) used on the mobile device.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1260,7 +1422,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Info",
         "description": "The branding, model, and marketing name used to identify the mobile device.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1273,7 +1436,8 @@
         "status": "PUBLIC",
         "uiName": "Mobile Device Marketing Name",
         "description": "The marketing name used for the mobile device.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1286,7 +1450,8 @@
         "status": "PUBLIC",
         "uiName": "Device Category",
         "description": "The type of device: desktop, tablet, or mobile.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1298,8 +1463,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Continent",
-        "description": "The continents of property users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' continents, derived from users' IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1311,8 +1477,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Sub Continent",
-        "description": "The sub-continent of users, derived from IP addresses. For example, Polynesia or Northern Europe.",
-        "allowedInSegments": "true"
+        "description": "Users' sub-continent, derived from their IP addresses or Geographical IDs. For example, Polynesia or Northern Europe.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1324,8 +1491,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Country",
-        "description": "The country of users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' country, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1337,8 +1505,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Region",
-        "description": "The region of users to your property, derived from IP addresses. In the U.S., a region is a state, such as New York.",
-        "allowedInSegments": "true"
+        "description": "Users' region, derived from their IP addresses or Geographical IDs. In U.S., a region is a state, New York, for example.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1350,8 +1519,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Metro",
-        "description": "The Designated Market Area (DMA) from where traffic arrived on your property.",
-        "allowedInSegments": "true"
+        "description": "The Designated Market Area (DMA) from where traffic arrived.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1363,8 +1533,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "City",
-        "description": "The cities of property users, derived from IP addresses.",
-        "allowedInSegments": "true"
+        "description": "Users' city, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1376,7 +1547,8 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Latitude",
-        "description": "The approximate latitude of the user's city. Derived from IP address. Locations north of the equator are represented by positive values and locations south of the equator by negative values."
+        "description": "The approximate latitude of users' city, derived from their IP addresses or Geographical IDs. Locations north of the equator have positive latitudes and locations south of the equator have negative latitudes.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1388,7 +1560,8 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Longitude",
-        "description": "The approximate longitude of the user's city. Derived from IP address. Locations east of the meridian are represented by positive values and locations west of the meridian by negative values."
+        "description": "The approximate latitude of users' city, derived from their IP addresses or Geographical IDs. Locations north of the equator have positive latitudes and locations south of the equator have negative latitudes.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1400,8 +1573,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Network Domain",
-        "description": "The domain name of the ISPs used by users to your property. This is derived from the domain name registered to the IP address.",
-        "allowedInSegments": "true"
+        "description": "The domain name of users' ISP, derived from the domain name registered to the ISP's IP address.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1413,8 +1587,9 @@
         "group": "Geo Network",
         "status": "PUBLIC",
         "uiName": "Service Provider",
-        "description": "The name of service providers used to reach your property. For example, if most users to your website come via the major service providers for cable internet, you will see the names of those cable service providers in this element.",
-        "allowedInSegments": "true"
+        "description": "The names of the service providers used to reach the property. For example, if most users of the website come via the major cable internet service providers, its value will be these service providers' names.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1426,8 +1601,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Flash Version",
-        "description": "The versions of Flash supported by users' browsers, including minor versions.",
-        "allowedInSegments": "true"
+        "description": "The version of Flash, including minor versions, supported by users' browsers.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1439,8 +1615,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Java Support",
-        "description": "Indicates Java support for users' browsers. The possible values are Yes or No where the first letter must be capitalized.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either Yes or No, indicating whether Java is enabled in users' browsers.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1452,8 +1629,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Language",
-        "description": "The language provided by the HTTP Request for the browser. Values are given as an ISO-639 code (e.g. en-gb for British English).",
-        "allowedInSegments": "true"
+        "description": "The language, in ISO-639 code format (e.g., en-gb for British English), provided by the HTTP Request for the browser.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1465,8 +1643,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Screen Colors",
-        "description": "The color depth of users' monitors, as retrieved from the DOM of the user's browser. For example 4-bit, 8-bit, 24-bit, or undefined-bit.",
-        "allowedInSegments": "true"
+        "description": "The color depth of users' monitors, retrieved from the DOM of users' browsers. For example, 4-bit, 8-bit, 24-bit, or undefined-bit.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1478,8 +1657,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Source Property Display Name",
-        "description": "Source property display name of roll-up properties. This is valid only for roll-up properties.",
-        "allowedInSegments": "true"
+        "description": "Source property display name of roll-up properties. This is valid for only roll-up properties.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1491,8 +1671,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Source Property Tracking ID",
-        "description": "Source property tracking ID of roll-up properties. This is valid only for roll-up properties.",
-        "allowedInSegments": "true"
+        "description": "Source property tracking ID of roll-up properties. This is valid for only roll-up properties.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1504,8 +1685,9 @@
         "group": "System",
         "status": "PUBLIC",
         "uiName": "Screen Resolution",
-        "description": "The screen resolution of users' screens. For example: 1024x738.",
-        "allowedInSegments": "true"
+        "description": "Resolution of users' screens, for example, 1024x738.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1515,9 +1697,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Endorsing URL",
-        "description": "For a social data hub activity, this value represents the URL of the social activity (e.g. the Google+ post URL, the blog comment URL, etc.)"
+        "description": "For a social data hub activity, this is the URL of the social activity (e.g., the Google+ post URL, the blog comment URL, etc.).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1527,9 +1710,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Display Name",
-        "description": "For a social data hub activity, this value represents the title of the social activity posted by the social network user."
+        "description": "For a social data hub activity, this is the title of the social activity posted by the social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1539,9 +1723,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Activity Post",
-        "description": "For a social data hub activity, this value represents the content of the social activity posted by the social network user (e.g. The message content of a Google+ post)"
+        "description": "For a social data hub activity, this is the content of the social activity (e.g., the content of a message posted in Google+) posted by social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1551,9 +1736,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Activity Timestamp",
-        "description": "For a social data hub activity, this value represents when the social activity occurred on the social network."
+        "description": "For a social data hub activity, this is the time when the social activity occurred on the social network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1563,9 +1749,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social User Handle",
-        "description": "For a social data hub activity, this value represents the social network handle (e.g. name or ID) of the user who initiated the social activity."
+        "description": "For a social data hub activity, this is the social network handle (e.g., name or ID) of users who initiated the social activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1575,9 +1762,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "User Photo URL",
-        "description": "For a social data hub activity, this value represents the URL of the photo associated with the user's social network profile."
+        "description": "For a social data hub activity, this is the URL of the photo associated with users' social network profiles.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1587,9 +1775,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "User Profile URL",
-        "description": "For a social data hub activity, this value represents the URL of the associated user's social network profile."
+        "description": "For a social data hub activity, this is the URL of the associated users' social network profiles.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1599,9 +1788,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Shared URL",
-        "description": "For a social data hub activity, this value represents the URL shared by the associated social network user."
+        "description": "For a social data hub activity, this is the URL shared by the associated social network users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1611,9 +1801,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Tags Summary",
-        "description": "For a social data hub activity, this is a comma-separated set of tags associated with the social activity."
+        "description": "For a social data hub activity, this is a comma-separated set of tags associated with the social activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1623,9 +1814,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Originating Social Action",
-        "description": "For a social data hub activity, this value represents the type of social action associated with the activity (e.g. vote, comment, +1, etc.)."
+        "description": "For a social data hub activity, this represents the type of social action (e.g., vote, comment, +1, etc.) associated with the activity.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1635,9 +1827,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Social Network and Action",
-        "description": "For a social data hub activity, this value represents the type of social action and the social network where the activity originated."
+        "description": "For a social data hub activity, this is the type of social action and the social network where the activity originated.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1647,9 +1840,10 @@
         "type": "METRIC",
         "dataType": "INTEGER",
         "group": "Social Activities",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Data Hub Activities",
-        "description": "The count of activities where a content URL was shared / mentioned on a social data hub partner network."
+        "description": "Total number of activities where a content URL was shared or mentioned on a social data hub partner network.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1662,7 +1856,8 @@
         "status": "PUBLIC",
         "uiName": "Hostname",
         "description": "The hostname from which the tracking request was made.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1674,8 +1869,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page",
-        "description": "A page on your website specified by path and/or query parameters. Use in conjunction with hostname to get the full URL of the page.",
-        "allowedInSegments": "true"
+        "description": "A page on the website specified by path and/or query parameters. Use this with hostname to get the page's full URL.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1687,7 +1883,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 1",
-        "description": "This dimension rolls up all the page paths in the first hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the first hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1699,7 +1896,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 2",
-        "description": "This dimension rolls up all the page paths in the second hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the second hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1711,7 +1909,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 3",
-        "description": "This dimension rolls up all the page paths in the third hierarchical level in pagePath."
+        "description": "This dimension rolls up all the page paths in the third hierarchical level in pagePath.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1723,7 +1922,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page path level 4",
-        "description": "This dimension rolls up all the page paths into hierarchical levels. Up to 4 pagePath levels maybe specified. All additional levels in the pagePath hierarchy are also rolled up in this dimension."
+        "description": "This dimension rolls up all the page paths into hierarchical levels. Up to 4 pagePath levels maybe specified. All additional levels in the pagePath hierarchy are also rolled up in this dimension.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1735,8 +1935,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page Title",
-        "description": "The title of a page. Keep in mind that multiple pages might have the same page title.",
-        "allowedInSegments": "true"
+        "description": "The page's title. Multiple pages might have the same page title.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1748,8 +1949,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Landing Page",
-        "description": "The first page in a user's session, or landing page.",
-        "allowedInSegments": "true"
+        "description": "The first page in users' sessions, or the landing page.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1761,7 +1963,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Second Page",
-        "description": "The second page in a user's session."
+        "description": "The second page in users' sessions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1773,8 +1976,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Exit Page",
-        "description": "The last page in a user's session, or exit page.",
-        "allowedInSegments": "true"
+        "description": "The last page or exit page in users' sessions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1786,7 +1990,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Previous Page Path",
-        "description": "A page on your property that was visited before another page on the same property. Typically used with the pagePath dimension."
+        "description": "A page visited before another page on the same property, typically used with the pagePath dimension.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1796,9 +2001,10 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Page Tracking",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Path",
-        "description": "A page on your website that was visited after another page on your website. Typically used with the previousPagePath dimension."
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:pagePath instead.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1811,7 +2017,8 @@
         "status": "PUBLIC",
         "uiName": "Page Depth",
         "description": "The number of pages visited by users during a session. The value is a histogram that counts pageviews across a range of possible values. In this calculation, all sessions will have at least one pageview, and some percentage of sessions will have more.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1823,7 +2030,8 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Page Value",
-        "description": "The average value of this page or set of pages. Page Value is (ga:transactionRevenue + ga:goalValueAll) / ga:uniquePageviews (for the page or set of pages)."
+        "description": "The average value of this page or set of pages, which is equal to (ga:transactionRevenue + ga:goalValueAll) / ga:uniquePageviews.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1835,8 +2043,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Entrances",
-        "description": "The number of entrances to your property measured as the first pageview in a session. Typically used with landingPagePath",
-        "allowedInSegments": "true"
+        "description": "The number of entrances to the property measured as the first pageview in a session, typically used with landingPagePath.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1849,7 +2058,8 @@
         "status": "PUBLIC",
         "uiName": "Entrances / Pageviews",
         "description": "The percentage of pageviews in which this page was the entrance.",
-        "calculation": "ga:entrances / ga:pageviews"
+        "calculation": "ga:entrances / ga:pageviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1861,8 +2071,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Pageviews",
-        "description": "The total number of pageviews for your property.",
-        "allowedInSegments": "true"
+        "description": "The total number of pageviews for the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1874,8 +2085,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Pages / Session",
-        "description": "The average number of pages viewed during a session on your property. Repeated views of a single page are counted.",
-        "calculation": "ga:pageviews / ga:sessions"
+        "description": "The average number of pages viewed during a session, including repeated views of a single page.",
+        "calculation": "ga:pageviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1888,8 +2100,9 @@
         "group": "Page Tracking",
         "status": "DEPRECATED",
         "uiName": "Pages / Session",
-        "description": "The average number of pages viewed during a session on your property. Repeated views of a single page are counted.",
-        "calculation": "ga:pageviews / ga:sessions"
+        "description": "The average number of pages viewed during a session, including repeated views of a single page.",
+        "calculation": "ga:pageviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1901,9 +2114,10 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Unique Views XX",
-        "description": "The number of different (unique) pages within a session for the specified content group. This takes into account both the pagePath and pageTitle to determine uniqueness.",
+        "description": "The number of unique content group views. Content group views in different sessions are counted as unique content group views. Both the pagePath and pageTitle are used to determine content group view uniqueness.",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "5"
+        "maxTemplateIndex": "5",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1915,8 +2129,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Pageviews",
-        "description": "The number of different (unique) pages within a session. This takes into account both the pagePath and pageTitle to determine uniqueness.",
-        "allowedInSegments": "true"
+        "description": "The number of unique page views. Page views in different sessions are counted as unique page views. Both the pagePath and pageTitle are used to determine page view uniqueness.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1928,8 +2143,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Time on Page",
-        "description": "How long a user spent on a particular page in seconds. Calculated by subtracting the initial view time for a particular page from the initial view time for a subsequent page. Thus, this metric does not apply to exit pages for your property.",
-        "allowedInSegments": "true"
+        "description": "Time (in seconds) users spent on a particular page, calculated by subtracting the initial view time for a particular page from the initial view time for a subsequent page. This metric does not apply to exit pages of the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1941,8 +2157,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Avg. Time on Page",
-        "description": "The average amount of time users spent viewing this page or a set of pages.",
-        "calculation": "ga:timeOnPage / (ga:pageviews - ga:exits)"
+        "description": "The average time users spent viewing this page or a set of pages.",
+        "calculation": "ga:timeOnPage / (ga:pageviews - ga:exits)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1954,8 +2171,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "Exits",
-        "description": "The number of exits from your property.",
-        "allowedInSegments": "true"
+        "description": "The number of exits from the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1967,8 +2185,9 @@
         "group": "Page Tracking",
         "status": "PUBLIC",
         "uiName": "% Exit",
-        "description": "The percentage of exits from your property that occurred out of the total page views.",
-        "calculation": "ga:exits / (ga:pageviews + ga:screenviews)"
+        "description": "The percentage of exits from the property that occurred out of the total pageviews.",
+        "calculation": "ga:exits / (ga:pageviews + ga:screenviews)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1980,8 +2199,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Status",
-        "description": "A boolean to distinguish whether internal search was used in a session. Values are Visits With Site Search and Visits Without Site Search.",
-        "allowedInSegments": "true"
+        "description": "A boolean, either Visits With Site Search or Visits Without Site Search, to distinguish whether internal search was used in a session.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -1993,8 +2213,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Term",
-        "description": "Search terms used by users within your property.",
-        "allowedInSegments": "true"
+        "description": "Search term used within the property.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2006,8 +2227,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Refined Keyword",
-        "description": "Subsequent keyword search terms or strings entered by users after a given initial string search.",
-        "allowedInSegments": "true"
+        "description": "Subsequent keyword search term or string entered by users after a given initial string search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2019,8 +2241,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Category",
-        "description": "The categories used for the internal search if you have this enabled for your profile. For example, you might have product categories such as electronics, furniture, or clothing.",
-        "allowedInSegments": "true"
+        "description": "The category used for the internal search if site search categories are enabled in the view. For example, the product category may be electronics, furniture, or clothing.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2032,7 +2255,8 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Start Page",
-        "description": "A page where the user initiated an internal search on your property."
+        "description": "The page where users initiated an internal search.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2044,7 +2268,22 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Destination Page",
-        "description": "The page the user immediately visited after performing an internal search on your site. (Usually the search results page)."
+        "description": "The page users immediately visited after performing an internal search on the site. This is usually the search results page.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:searchAfterDestinationPage",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Internal Search",
+        "status": "PUBLIC",
+        "uiName": "Search Destination Page",
+        "description": "The page that users visited after performing an internal search on the site.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2056,7 +2295,8 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Results Pageviews",
-        "description": "The number of times a search result page was viewed after performing a search."
+        "description": "The number of times a search result page was viewed.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2068,8 +2308,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Total Unique Searches",
-        "description": "The total number of unique keywords from internal searches within a session. For example if \"shoes\" was searched for 3 times in a session, it will be only counted once.",
-        "allowedInSegments": "true"
+        "description": "Total number of unique keywords from internal searches within a session. For example, if \"shoes\" was searched for 3 times in a session, it would be counted only once.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2081,8 +2322,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Results Pageviews / Search",
-        "description": "The average number of times people viewed a search results page after performing a search.",
-        "calculation": "ga:searchResultViews / ga:searchUniques"
+        "description": "The average number of times people viewed a page as a result of a search.",
+        "calculation": "ga:searchResultViews / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2094,8 +2336,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Sessions with Search",
-        "description": "The total number of sessions that included an internal search",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions that included an internal search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2108,8 +2351,9 @@
         "group": "Internal Search",
         "status": "DEPRECATED",
         "uiName": "Sessions with Search",
-        "description": "The total number of sessions that included an internal search",
-        "allowedInSegments": "true"
+        "description": "The total number of sessions that included an internal search.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2122,7 +2366,8 @@
         "status": "PUBLIC",
         "uiName": "% Sessions with Search",
         "description": "The percentage of sessions with search.",
-        "calculation": "ga:searchSessions / ga:sessions"
+        "calculation": "ga:searchSessions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2136,7 +2381,8 @@
         "status": "DEPRECATED",
         "uiName": "% Sessions with Search",
         "description": "The percentage of sessions with search.",
-        "calculation": "ga:searchSessions / ga:sessions"
+        "calculation": "ga:searchSessions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2148,8 +2394,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Depth",
-        "description": "The average number of subsequent page views made on your property after a use of your internal search feature.",
-        "allowedInSegments": "true"
+        "description": "The total number of subsequent page views made after a use of the site's internal search feature.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2161,8 +2408,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Average Search Depth",
-        "description": "The average number of pages people viewed after performing a search on your property.",
-        "calculation": "ga:searchDepth / ga:searchUniques"
+        "description": "The average number of pages people viewed after performing a search.",
+        "calculation": "ga:searchDepth / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2174,8 +2422,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Refinements",
-        "description": "The total number of times a refinement (transition) occurs between internal search keywords within a session. For example if the sequence of keywords is: \"shoes\", \"shoes\", \"pants\", \"pants\", this metric will be one because the transition between \"shoes\" and \"pants\" is different.",
-        "allowedInSegments": "true"
+        "description": "The total number of times a refinement (transition) occurs between internal keywords search within a session. For example, if the sequence of keywords is \"shoes\", \"shoes\", \"pants\", \"pants\", this metric will be one because the transition between \"shoes\" and \"pants\" is different.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2187,8 +2436,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "% Search Refinements",
-        "description": "The percentage of number of times a refinement (i.e., transition) occurs between internal search keywords within a session.",
-        "calculation": "ga:searchRefinements / ga:searchResultViews"
+        "description": "The percentage of the number of times a refinement (i.e., transition) occurs between internal keywords search within a session.",
+        "calculation": "ga:searchRefinements / ga:searchResultViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2200,8 +2450,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Time after Search",
-        "description": "The session duration on your property where a use of your internal search feature occurred.",
-        "allowedInSegments": "true"
+        "description": "The session duration when the site's internal search feature is used.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2213,8 +2464,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Time after Search",
-        "description": "The average amount of time people spent on your property after searching.",
-        "calculation": "ga:searchDuration / ga:searchUniques"
+        "description": "The average time (in seconds) users, after searching, spent on the property.",
+        "calculation": "ga:searchDuration / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2226,8 +2478,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Search Exits",
-        "description": "The number of exits on your site that occurred following a search result from your internal search feature.",
-        "allowedInSegments": "true"
+        "description": "The number of exits on the site that occurred following a search result from the site's internal search feature.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2239,8 +2492,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "% Search Exits",
-        "description": "The percentage of searches that resulted in an immediate exit from your property.",
-        "calculation": "ga:searchExits / ga:searchUniques"
+        "description": "The percentage of searches that resulted in an immediate exit from the property.",
+        "calculation": "ga:searchExits / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2255,7 +2509,8 @@
         "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to the requested goal number.",
         "calculation": "ga:goalXXCompletions / ga:searchUniques",
         "minTemplateIndex": "1",
-        "maxTemplateIndex": "20"
+        "maxTemplateIndex": "20",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2267,8 +2522,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Site Search Goal Conversion Rate",
-        "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to at least one of your goals.",
-        "calculation": "ga:goalCompletionsAll / ga:searchUniques"
+        "description": "The percentage of search sessions (i.e., sessions that included at least one search) which resulted in a conversion to at least one of the goals.",
+        "calculation": "ga:goalCompletionsAll / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2280,8 +2536,9 @@
         "group": "Internal Search",
         "status": "PUBLIC",
         "uiName": "Per Search Goal Value",
-        "description": "The average goal value of a search on your property.",
-        "calculation": "ga:goalValueAll / ga:searchUniques"
+        "description": "The average goal value of a search.",
+        "calculation": "ga:goalValueAll / ga:searchUniques",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2293,7 +2550,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Load Time (ms)",
-        "description": "Total Page Load Time is the amount of time (in milliseconds) it takes for pages from the sample set to load, from initiation of the pageview (e.g. click on a page link) to load completion in the browser."
+        "description": "Total time (in milliseconds), from pageview initiation (e.g., a click on a page link) to page load completion in the browser, the pages in the sample set take to load.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2305,7 +2563,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Load Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the average page load time."
+        "description": "The sample set (or count) of pageviews used to calculate the average page load time.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2317,8 +2576,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Page Load Time (sec)",
-        "description": "The average amount of time (in seconds) it takes for pages from the sample set to load, from initiation of the pageview (e.g. click on a page link) to load completion in the browser.",
-        "calculation": "(ga:pageLoadTime / ga:pageLoadSample / 1000)"
+        "description": "The average time (in seconds) pages from the sample set take to load, from initiation of the pageview (e.g., a click on a page link) to load completion in the browser.",
+        "calculation": "(ga:pageLoadTime / ga:pageLoadSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2330,7 +2590,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Domain Lookup Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in DNS lookup for this page among all samples."
+        "description": "The total time (in milliseconds) all samples spent in DNS lookup for this page.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2342,8 +2603,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Domain Lookup Time (sec)",
-        "description": "The average amount of time (in seconds) spent in DNS lookup for this page.",
-        "calculation": "(ga:domainLookupTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in DNS lookup for this page.",
+        "calculation": "(ga:domainLookupTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2355,7 +2617,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Page Download Time (ms)",
-        "description": "The total amount of time (in milliseconds) to download this page among all samples."
+        "description": "The total time (in milliseconds) to download this page among all samples.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2367,8 +2630,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Page Download Time (sec)",
-        "description": "The average amount of time (in seconds) to download this page.",
-        "calculation": "(ga:pageDownloadTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) to download this page.",
+        "calculation": "(ga:pageDownloadTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2380,7 +2644,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Redirection Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in redirects before fetching this page among all samples. If there are no redirects, the value for this metric is expected to be 0."
+        "description": "The total time (in milliseconds) all samples spent in redirects before fetching this page. If there are no redirects, this is 0.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2392,8 +2657,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Redirection Time (sec)",
-        "description": "The average amount of time (in seconds) spent in redirects before fetching this page. If there are no redirects, the value for this metric is expected to be 0.",
-        "calculation": "(ga:redirectionTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in redirects before fetching this page. If there are no redirects, this is 0.",
+        "calculation": "(ga:redirectionTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2405,7 +2671,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Server Connection Time (ms)",
-        "description": "The total amount of time (in milliseconds) spent in establishing TCP connection for this page among all samples."
+        "description": "Total time (in milliseconds) all samples spent in establishing a TCP connection to this page.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2417,8 +2684,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Server Connection Time (sec)",
-        "description": "The average amount of time (in seconds) spent in establishing TCP connection for this page.",
-        "calculation": "(ga:serverConnectionTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) spent in establishing a TCP connection to this page.",
+        "calculation": "(ga:serverConnectionTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2430,7 +2698,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Server Response Time (ms)",
-        "description": "The total amount of time (in milliseconds) your server takes to respond to a user request among all samples, including the network time from user's location to your server."
+        "description": "The total time (in milliseconds) the site's server takes to respond to users' requests among all samples; this includes the network time from users' locations to the server.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2442,8 +2711,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Server Response Time (sec)",
-        "description": "The average amount of time (in seconds) your server takes to respond to a user request, including the network time from user's location to your server.",
-        "calculation": "(ga:serverResponseTime / ga:speedMetricsSample / 1000)"
+        "description": "The average time (in seconds) the site's server takes to respond to users' requests; this includes the network time from users' locations to the server.",
+        "calculation": "(ga:serverResponseTime / ga:speedMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2455,7 +2725,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Speed Metrics Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the averages for site speed metrics. This metric is used in all site speed average calculations including avgDomainLookupTime, avgPageDownloadTime, avgRedirectionTime, avgServerConnectionTime, and avgServerResponseTime."
+        "description": "The sample set (or count) of pageviews used to calculate the averages of site speed metrics. This metric is used in all site speed average calculations, including avgDomainLookupTime, avgPageDownloadTime, avgRedirectionTime, avgServerConnectionTime, and avgServerResponseTime.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2467,7 +2738,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Document Interactive Time (ms)",
-        "description": "The time the browser takes (in milliseconds) to parse the document (DOMInteractive), including the network time from the user's location to your server. At this time, the user can interact with the Document Object Model even though it is not fully loaded."
+        "description": "The time (in milliseconds), including the network time from users' locations to the site's server, the browser takes to parse the document (DOMInteractive). At this time, users can interact with the Document Object Model even though it is not fully loaded.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2479,8 +2751,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Document Interactive Time (sec)",
-        "description": "The average time (in seconds) it takes the browser to parse the document and execute deferred and parser-inserted scripts including the network time from the user's location to your server.",
-        "calculation": "(ga:domInteractiveTime / ga:domLatencyMetricsSample / 1000)"
+        "description": "The average time (in seconds), including the network time from users' locations to the site's server, the browser takes to parse the document and execute deferred and parser-inserted scripts.",
+        "calculation": "(ga:domInteractiveTime / ga:domLatencyMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2492,7 +2765,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Document Content Loaded Time (ms)",
-        "description": "The time the browser takes (in milliseconds) to parse the document and execute deferred and parser-inserted scripts (DOMContentLoaded), including the network time from the user's location to your server. Parsing of the document is finished, the Document Object Model is ready, but referenced style sheets, images, and subframes may not be finished loading. This event is often the starting point for javascript framework execution, e.g., JQuery's onready() callback, etc."
+        "description": "The time (in milliseconds), including the network time from users' locations to the site's server, the browser takes to parse the document and execute deferred and parser-inserted scripts (DOMContentLoaded). When parsing of the document is finished, the Document Object Model (DOM) is ready, but the referenced style sheets, images, and subframes may not be finished loading. This is often the starting point of Javascript framework execution, e.g., JQuery's onready() callback.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2504,8 +2778,9 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "Avg. Document Content Loaded Time (sec)",
-        "description": "The average time (in seconds) it takes the browser to parse the document.",
-        "calculation": "(ga:domContentLoadedTime / ga:domLatencyMetricsSample / 1000)"
+        "description": "The average time (in seconds) the browser takes to parse the document.",
+        "calculation": "(ga:domContentLoadedTime / ga:domLatencyMetricsSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2517,7 +2792,8 @@
         "group": "Site Speed",
         "status": "PUBLIC",
         "uiName": "DOM Latency Metrics Sample",
-        "description": "The sample set (or count) of pageviews used to calculate the averages for site speed DOM metrics. This metric is used in the avgDomContentLoadedTime and avgDomInteractiveTime calculations."
+        "description": "Sample set (or count) of pageviews used to calculate the averages for site speed DOM metrics. This metric is used to calculate ga:avgDomContentLoadedTime and ga:avgDomInteractiveTime.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2529,8 +2805,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Installer ID",
-        "description": "ID of the installer (e.g., Google Play Store) from which the app was downloaded. By default, the app installer id is set based on the PackageManager#getInstallerPackageName method.",
-        "allowedInSegments": "true"
+        "description": "The ID of the app installer (e.g., Google Play Store) from which the app was downloaded. By default, the app installer ID is set by the PackageManager#getInstallerPackageName method.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2542,8 +2819,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Version",
-        "description": "The version of the application.",
-        "allowedInSegments": "true"
+        "description": "The application version.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2555,8 +2833,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App Name",
-        "description": "The name of the application.",
-        "allowedInSegments": "true"
+        "description": "The application name.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2568,8 +2847,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "App ID",
-        "description": "The ID of the application.",
-        "allowedInSegments": "true"
+        "description": "The application ID.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2582,7 +2862,8 @@
         "status": "PUBLIC",
         "uiName": "Screen Name",
         "description": "The name of the screen.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2594,8 +2875,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Screen Depth",
-        "description": "The number of screenviews per session reported as a string. Can be useful for historgrams.",
-        "allowedInSegments": "true"
+        "description": "The number of screenviews (reported as a string) per session, useful for historgrams.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2607,8 +2889,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Landing Screen",
-        "description": "The name of the first screen viewed.",
-        "allowedInSegments": "true"
+        "description": "The name of the first viewed screen.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2620,8 +2903,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Exit Screen",
-        "description": "The name of the screen when the user exited the application.",
-        "allowedInSegments": "true"
+        "description": "The name of the screen where users exited the application.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2634,7 +2918,8 @@
         "status": "PUBLIC",
         "uiName": "Screen Views",
         "description": "The total number of screenviews.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2648,7 +2933,8 @@
         "status": "DEPRECATED",
         "uiName": "Screen Views",
         "description": "The total number of screenviews.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2660,8 +2946,9 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Screen Views",
-        "description": "The number of different (unique) screenviews within a session.",
-        "allowedInSegments": "true"
+        "description": "The number of unique screen views. Screen views in different sessions are counted as separate screen views.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2674,8 +2961,9 @@
         "group": "App Tracking",
         "status": "DEPRECATED",
         "uiName": "Unique Screen Views",
-        "description": "The number of different (unique) screenviews within a session.",
-        "allowedInSegments": "true"
+        "description": "The number of unique screen views. Screen views in different sessions are counted as separate screen views.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2688,7 +2976,8 @@
         "status": "PUBLIC",
         "uiName": "Screens / Session",
         "description": "The average number of screenviews per session.",
-        "calculation": "ga:screenviews / ga:sessions"
+        "calculation": "ga:screenviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2702,7 +2991,8 @@
         "status": "DEPRECATED",
         "uiName": "Screens / Session",
         "description": "The average number of screenviews per session.",
-        "calculation": "ga:screenviews / ga:sessions"
+        "calculation": "ga:screenviews / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2715,7 +3005,8 @@
         "status": "PUBLIC",
         "uiName": "Time on Screen",
         "description": "The time spent viewing the current screen.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2727,7 +3018,8 @@
         "group": "App Tracking",
         "status": "PUBLIC",
         "uiName": "Avg. Time on Screen",
-        "description": "The average amount of time users spent on a screen in seconds."
+        "description": "Average time (in seconds) users spent on a screen.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2739,8 +3031,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Category",
-        "description": "The category of the event.",
-        "allowedInSegments": "true"
+        "description": "The event category.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2752,8 +3045,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Action",
-        "description": "The action of the event.",
-        "allowedInSegments": "true"
+        "description": "Event action.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2765,8 +3059,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Label",
-        "description": "The label of the event.",
-        "allowedInSegments": "true"
+        "description": "Event label.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2779,7 +3074,8 @@
         "status": "PUBLIC",
         "uiName": "Total Events",
         "description": "The total number of events for the profile, across all categories.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2791,7 +3087,8 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Unique Events",
-        "description": "The total number of unique events for the profile, across all categories."
+        "description": "The number of unique events. Events in different sessions are counted as separate events.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2803,8 +3100,9 @@
         "group": "Event Tracking",
         "status": "PUBLIC",
         "uiName": "Event Value",
-        "description": "The total value of events for the profile.",
-        "allowedInSegments": "true"
+        "description": "Total value of events for the profile.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2817,7 +3115,8 @@
         "status": "PUBLIC",
         "uiName": "Avg. Value",
         "description": "The average value of an event.",
-        "calculation": "ga:eventValue / ga:totalEvents"
+        "calculation": "ga:eventValue / ga:totalEvents",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2830,7 +3129,8 @@
         "status": "PUBLIC",
         "uiName": "Sessions with Event",
         "description": "The total number of sessions with events.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2844,7 +3144,8 @@
         "status": "DEPRECATED",
         "uiName": "Sessions with Event",
         "description": "The total number of sessions with events.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2857,7 +3158,8 @@
         "status": "PUBLIC",
         "uiName": "Events / Session with Event",
         "description": "The average number of events per session with event.",
-        "calculation": "ga:totalEvents / ga:sessionsWithEvent"
+        "calculation": "ga:totalEvents / ga:sessionsWithEvent",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2871,7 +3173,8 @@
         "status": "DEPRECATED",
         "uiName": "Events / Session with Event",
         "description": "The average number of events per session with event.",
-        "calculation": "ga:totalEvents / ga:sessionsWithEvent"
+        "calculation": "ga:totalEvents / ga:sessionsWithEvent",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2883,8 +3186,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Transaction ID",
-        "description": "The transaction ID for the shopping cart purchase as supplied by your ecommerce tracking method.",
-        "allowedInSegments": "true"
+        "description": "The transaction ID, supplied by the ecommerce tracking method, for the purchase in the shopping cart.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2896,8 +3200,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Affiliation",
-        "description": "Typically used to designate a supplying company or brick and mortar location; product affiliation.",
-        "allowedInSegments": "true"
+        "description": "A product affiliation to designate a supplying company or brick and mortar location.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2910,7 +3215,8 @@
         "status": "PUBLIC",
         "uiName": "Sessions to Transaction",
         "description": "The number of sessions between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2924,7 +3230,8 @@
         "status": "DEPRECATED",
         "uiName": "Sessions to Transaction",
         "description": "The number of sessions between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2937,7 +3244,8 @@
         "status": "PUBLIC",
         "uiName": "Days to Transaction",
         "description": "The number of days between users' purchases and the related campaigns that lead to the purchases.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2949,8 +3257,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product SKU",
-        "description": "The product sku for purchased items as you have defined them in your ecommerce tracking application.",
-        "allowedInSegments": "true"
+        "description": "The product SKU, defined in the ecommerce tracking application, for purchased items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2962,8 +3271,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product",
-        "description": "The product name for purchased items as supplied by your ecommerce tracking application.",
-        "allowedInSegments": "true"
+        "description": "The product name, supplied by the ecommerce tracking application, for purchased items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2975,8 +3285,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Category",
-        "description": "Any product variations (size, color) for purchased items as supplied by your ecommerce application. Not compatible with Enhanced Ecommerce.",
-        "allowedInSegments": "true"
+        "description": "Any product variation (size, color) supplied by the ecommerce application for purchased items, not compatible with Enhanced Ecommerce.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -2988,7 +3299,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Currency Code",
-        "description": "The local currency code of the transaction based on ISO 4217 standard."
+        "description": "The local currency code (based on ISO 4217 standard) of the transaction.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3001,7 +3313,8 @@
         "status": "PUBLIC",
         "uiName": "Transactions",
         "description": "The total number of transactions.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3013,8 +3326,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Ecommerce Conversion Rate",
-        "description": "The average number of transactions for a session on your property.",
-        "calculation": "ga:transactions / ga:sessions"
+        "description": "The average number of transactions in a session.",
+        "calculation": "ga:transactions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3027,8 +3341,9 @@
         "group": "Ecommerce",
         "status": "DEPRECATED",
         "uiName": "Ecommerce Conversion Rate",
-        "description": "The average number of transactions for a session on your property.",
-        "calculation": "ga:transactions / ga:sessions"
+        "description": "The average number of transactions in a session.",
+        "calculation": "ga:transactions / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3040,8 +3355,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Revenue",
-        "description": "The total sale revenue provided in the transaction excluding shipping and tax.",
-        "allowedInSegments": "true"
+        "description": "The total sale revenue (excluding shipping and tax) of the transaction.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3053,8 +3369,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Average Order Value",
-        "description": "The average revenue for an e-commerce transaction.",
-        "calculation": "ga:transactionRevenue / ga:transactions"
+        "description": "The average revenue of an ecommerce transaction.",
+        "calculation": "ga:transactionRevenue / ga:transactions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3066,8 +3383,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Per Session Value",
-        "description": "Average transaction revenue for a session on your property.",
-        "calculation": "ga:transactionRevenue / ga:sessions"
+        "description": "Average transaction revenue for a session.",
+        "calculation": "ga:transactionRevenue / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3080,8 +3398,9 @@
         "group": "Ecommerce",
         "status": "DEPRECATED",
         "uiName": "Per Session Value",
-        "description": "Average transaction revenue for a session on your property.",
-        "calculation": "ga:transactionRevenue / ga:sessions"
+        "description": "Average transaction revenue for a session.",
+        "calculation": "ga:transactionRevenue / ga:sessions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3094,7 +3413,8 @@
         "status": "PUBLIC",
         "uiName": "Shipping",
         "description": "The total cost of shipping.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3106,8 +3426,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Tax",
-        "description": "The total amount of tax.",
-        "allowedInSegments": "true"
+        "description": "Total tax for the transaction.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3119,8 +3440,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Total Value",
-        "description": "Total value for your property (including total revenue and total goal value).",
-        "calculation": "(ga:transactionRevenue + ga:goalValueAll)"
+        "description": "Total value for the property (including total revenue and total goal value).",
+        "calculation": "(ga:transactionRevenue + ga:goalValueAll)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3132,8 +3454,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Quantity",
-        "description": "The total number of items purchased. For example, if users purchase 2 frisbees and 5 tennis balls, 7 items have been purchased.",
-        "allowedInSegments": "true"
+        "description": "Total number of items purchased. For example, if users purchase 2 frisbees and 5 tennis balls, this will be 7.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3145,8 +3468,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Unique Purchases",
-        "description": "The number of product sets purchased. For example, if users purchase 2 frisbees and 5 tennis balls from your site, 2 unique products have been purchased.",
-        "allowedInSegments": "true"
+        "description": "The number of product sets purchased. For example, if users purchase 2 frisbees and 5 tennis balls from the site, this will be 2.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3159,7 +3483,8 @@
         "status": "PUBLIC",
         "uiName": "Average Price",
         "description": "The average revenue per item.",
-        "calculation": "ga:itemRevenue / ga:itemQuantity"
+        "calculation": "ga:itemRevenue / ga:itemQuantity",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3171,8 +3496,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Revenue",
-        "description": "The total revenue from purchased product items on your property.",
-        "allowedInSegments": "true"
+        "description": "The total revenue from purchased product items.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3185,7 +3511,8 @@
         "status": "PUBLIC",
         "uiName": "Average QTY",
         "description": "The average quantity of this item (or group of items) sold per purchase.",
-        "calculation": "ga:itemQuantity / ga:uniquePurchases"
+        "calculation": "ga:itemQuantity / ga:uniquePurchases",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3197,7 +3524,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Revenue",
-        "description": "Transaction revenue in local currency."
+        "description": "Transaction revenue in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3209,7 +3537,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Shipping",
-        "description": "Transaction shipping cost in local currency."
+        "description": "Transaction shipping cost in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3221,7 +3550,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Tax",
-        "description": "Transaction tax in local currency."
+        "description": "Transaction tax in local currency.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3234,7 +3564,8 @@
         "status": "PUBLIC",
         "uiName": "Local Product Revenue",
         "description": "Product revenue in local currency.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3245,8 +3576,9 @@
         "dataType": "STRING",
         "group": "Social Interactions",
         "status": "PUBLIC",
-        "uiName": "Social Source",
-        "description": "For social interactions, a value representing the social network being tracked."
+        "uiName": "Social Network",
+        "description": "For social interactions, this represents the social network being tracked.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3258,7 +3590,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Action",
-        "description": "For social interactions, a value representing the social action being tracked (e.g. +1, bookmark)"
+        "description": "For social interactions, this is the social action (e.g., +1, bookmark) being tracked.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3269,8 +3602,9 @@
         "dataType": "STRING",
         "group": "Social Interactions",
         "status": "PUBLIC",
-        "uiName": "Social Source and Action",
-        "description": "For social interactions, a value representing the concatenation of the socialInteractionNetwork and socialInteractionAction action being tracked at this hit level (e.g. Google: +1)"
+        "uiName": "Social Network and Action",
+        "description": "For social interactions, this is the concatenation of the socialInteractionNetwork and socialInteractionAction action (e.g., Google: +1) being tracked at this hit level.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3282,7 +3616,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Entity",
-        "description": "For social interactions, a value representing the URL (or resource) which receives the social network action."
+        "description": "For social interactions, this is the URL (or resource) which receives the social network action.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3294,7 +3629,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Type",
-        "description": "Engagement type. Possible values are \"Socially Engaged\" or \"Not Socially Engaged\"."
+        "description": "Engagement type, either \"Socially Engaged\" or \"Not Socially Engaged\".",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3306,7 +3642,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Social Actions",
-        "description": "The total number of social interactions on your property."
+        "description": "The total number of social interactions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3318,7 +3655,8 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Unique Social Actions",
-        "description": "The number of sessions during which the specified social action(s) occurred at least once. This is based on the the unique combination of socialInteractionNetwork, socialInteractionAction, and socialInteractionTarget."
+        "description": "The number of sessions during which the specified social action(s) occurred at least once. This is based on the the unique combination of socialInteractionNetwork, socialInteractionAction, and socialInteractionTarget.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3330,8 +3668,9 @@
         "group": "Social Interactions",
         "status": "PUBLIC",
         "uiName": "Actions Per Social Session",
-        "description": "The number of social interactions per session on your property.",
-        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions"
+        "description": "The number of social interactions per session.",
+        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3344,8 +3683,9 @@
         "group": "Social Interactions",
         "status": "DEPRECATED",
         "uiName": "Actions Per Social Session",
-        "description": "The number of social interactions per session on your property.",
-        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions"
+        "description": "The number of social interactions per session.",
+        "calculation": "ga:socialInteractions / ga:uniqueSocialInteractions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3357,8 +3697,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Timing Category",
-        "description": "A string for categorizing all user timing variables into logical groups for easier reporting purposes.",
-        "allowedInSegments": "true"
+        "description": "For easier reporting purposes, this is used to categorize all user timing variables into logical groups.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3371,7 +3712,8 @@
         "status": "PUBLIC",
         "uiName": "Timing Label",
         "description": "The name of the resource's action being tracked.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3383,8 +3725,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Timing Variable",
-        "description": "A value that can be used to add flexibility in visualizing user timings in the reports.",
-        "allowedInSegments": "true"
+        "description": "Used to add flexibility to visualize user timings in the reports.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3396,7 +3739,8 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "User Timing (ms)",
-        "description": "The total number of milliseconds for a user timing."
+        "description": "Total number of milliseconds for user timing.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3408,7 +3752,8 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "User Timing Sample",
-        "description": "The number of hits that were sent for a particular userTimingCategory, userTimingLabel, and userTimingVariable."
+        "description": "The number of hits sent for a particular userTimingCategory, userTimingLabel, or userTimingVariable.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3420,8 +3765,9 @@
         "group": "User Timings",
         "status": "PUBLIC",
         "uiName": "Avg. User Timing (sec)",
-        "description": "The average amount of elapsed time.",
-        "calculation": "(ga:userTimingValue / ga:userTimingSample / 1000)"
+        "description": "The average elapsed time.",
+        "calculation": "(ga:userTimingValue / ga:userTimingSample / 1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3434,7 +3780,8 @@
         "status": "PUBLIC",
         "uiName": "Exception Description",
         "description": "The description for the exception.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3446,8 +3793,9 @@
         "group": "Exceptions",
         "status": "PUBLIC",
         "uiName": "Exceptions",
-        "description": "The number of exceptions that were sent to Google Analytics.",
-        "allowedInSegments": "true"
+        "description": "The number of exceptions sent to Google Analytics.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3460,7 +3808,8 @@
         "status": "PUBLIC",
         "uiName": "Exceptions / Screen",
         "description": "The number of exceptions thrown divided by the number of screenviews.",
-        "calculation": "ga:exceptions / ga:screenviews"
+        "calculation": "ga:exceptions / ga:screenviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3473,7 +3822,8 @@
         "status": "PUBLIC",
         "uiName": "Crashes",
         "description": "The number of exceptions where isFatal is set to true.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3486,7 +3836,8 @@
         "status": "PUBLIC",
         "uiName": "Crashes / Screen",
         "description": "The number of fatal exceptions thrown divided by the number of screenviews.",
-        "calculation": "ga:fatalExceptions / ga:screenviews"
+        "calculation": "ga:fatalExceptions / ga:screenviews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3498,8 +3849,9 @@
         "group": "Content Experiments",
         "status": "PUBLIC",
         "uiName": "Experiment ID",
-        "description": "The user-scoped id of the content experiment that the user was exposed to when the metrics were reported.",
-        "allowedInSegments": "true"
+        "description": "The user-scoped ID of the content experiment that users were exposed to when the metrics were reported.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3510,9 +3862,10 @@
         "dataType": "STRING",
         "group": "Content Experiments",
         "status": "PUBLIC",
-        "uiName": "Variation",
-        "description": "The user-scoped id of the particular variation that the user was exposed to during a content experiment.",
-        "allowedInSegments": "true"
+        "uiName": "Variant",
+        "description": "The user-scoped ID of the particular variant that users were exposed to during a content experiment.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3524,12 +3877,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Custom Dimension XX",
-        "description": "The name of the requested custom dimension, where XX refers the number/index of the custom dimension.",
+        "description": "The value of the requested custom dimension, where XX refers to the number or index of the custom dimension.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3546,7 +3900,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3558,12 +3913,13 @@
         "group": "Custom Variables or Columns",
         "status": "PUBLIC",
         "uiName": "Custom Metric XX Value",
-        "description": "The name of the requested custom metric, where XX refers the number/index of the custom metric.",
+        "description": "The value of the requested custom metric, where XX refers to the number or index of the custom metric. Note that the data type of ga:metricXX can be INTEGER, CURRENCY, or TIME.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "20",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "200",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3580,7 +3936,8 @@
         "maxTemplateIndex": "5",
         "premiumMinTemplateIndex": "1",
         "premiumMaxTemplateIndex": "50",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3592,7 +3949,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Date",
-        "description": "The date of the session formatted as YYYYMMDD."
+        "description": "The date of the session formatted as YYYYMMDD.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3604,7 +3962,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Year",
-        "description": "The year of the session. A four-digit year from 2005 to the current year."
+        "description": "The year of the session, a four-digit year from 2005 to the current year.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3616,7 +3975,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month of the year",
-        "description": "The month of the session. A two digit integer from 01 to 12."
+        "description": "Month of the session, a two digit integer from 01 to 12.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3628,7 +3988,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week of the Year",
-        "description": "The week of the session. A two-digit number from 01 to 53. Each week starts on Sunday."
+        "description": "The week of the session, a two-digit number from 01 to 53. Each week starts on Sunday.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3640,7 +4001,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of the month",
-        "description": "The day of the month. A two-digit number from 01 to 31."
+        "description": "The day of the month, a two-digit number from 01 to 31.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3652,8 +4014,9 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour",
-        "description": "A two-digit hour of the day ranging from 00-23 in the timezone configured for the account. This value is also corrected for daylight savings time, adhering to all local rules for daylight savings time. If your timezone follows daylight savings time, there will be an apparent bump in the number of sessions during the change-over hour (e.g. between 1:00 and 2:00) for the day per year when that hour repeats. A corresponding hour with zero sessions will occur at the opposite changeover. (Google Analytics does not track user time more precisely than hours.)",
-        "allowedInSegments": "true"
+        "description": "A two-digit hour of the day ranging from 00-23 in the timezone configured for the account. This value is also corrected for daylight savings time. If the timezone follows daylight savings time, there will be an apparent bump in the number of sessions during the changeover hour (e.g., between 1:00 and 2:00) for the day per year when that hour repeats. A corresponding hour with zero sessions will occur at the opposite changeover. (Google Analytics does not track user time more precisely than hours.)",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3665,8 +4028,9 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Minute",
-        "description": "Returns the minute in the hour. The possible values are between 00 and 59.",
-        "allowedInSegments": "true"
+        "description": "Returns the minutes, between 00 and 59, in the hour.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3678,7 +4042,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month Index",
-        "description": "Index for each month in the specified date range. Index for the first month in the date range is 0, 1 for the second month, and so on. The index corresponds to month entries."
+        "description": "The index for a month in the specified date range. In the date range, the index for the first month is 0, for the second month 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3690,7 +4055,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week Index",
-        "description": "Index for each week in the specified date range. Index for the first week in the date range is 0, 1 for the second week, and so on. The index corresponds to week entries."
+        "description": "The index for each week in the specified date range. The index for the first week in the date range is 0, for the second week 1, and so on. The index corresponds to week entries.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3702,7 +4068,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day Index",
-        "description": "Index for each day in the specified date range. Index for the first day (i.e., start-date) in the date range is 0, 1 for the second day, and so on."
+        "description": "The index for each day in the specified date range. The index for the first day (i.e., start-date) in the date range is 0, for the second day 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3714,7 +4081,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Minute Index",
-        "description": "Index for each minute in the specified date range. Index for the first minute of first day (i.e., start-date) in the date range is 0, 1 for the next minute, and so on."
+        "description": "The index for each minute in the specified date range. The index for the first minute of the first day (i.e., start-date) in the date range is 0, for the next minute 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3726,7 +4094,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of Week",
-        "description": "The day of the week. A one-digit number from 0 (Sunday) to 6 (Saturday)."
+        "description": "Day of the week, a one-digit number from 0 (Sunday) to 6 (Saturday).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3738,7 +4107,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Day of Week Name",
-        "description": "The name of the day of the week (in English)."
+        "description": "Name (in English) of the day of the week.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3750,7 +4120,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour of Day",
-        "description": "Combined values of ga:date and ga:hour."
+        "description": "Combined values of ga:date and ga:hour.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3762,7 +4133,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Month of Year",
-        "description": "Combined values of ga:year and ga:month."
+        "description": "Combined values of ga:year and ga:month.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3774,7 +4146,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Week of Year",
-        "description": "Combined values of ga:year and ga:week."
+        "description": "Combined values of ga:year and ga:week.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3786,7 +4159,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Week of the Year",
-        "description": "The ISO week number, where each week starts with a Monday. Details: http://en.wikipedia.org/wiki/ISO_week_date. ga:isoWeek should only be used with ga:isoYear since ga:year represents gregorian calendar."
+        "description": "ISO week number, where each week starts on Monday. For details, see http://en.wikipedia.org/wiki/ISO_week_date. ga:isoWeek should only be used with ga:isoYear because ga:year represents Gregorian calendar.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3798,7 +4172,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Year",
-        "description": "The ISO year of the session. Details: http://en.wikipedia.org/wiki/ISO_week_date. ga:isoYear should only be used with ga:isoWeek since ga:week represents gregorian calendar."
+        "description": "The ISO year of the session. For details, see http://en.wikipedia.org/wiki/ISO_week_date. ga:isoYear should only be used with ga:isoWeek because ga:week represents Gregorian calendar.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3810,7 +4185,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "ISO Week of ISO Year",
-        "description": "Combined values of ga:isoYear and ga:isoWeek."
+        "description": "Combined values of ga:isoYear and ga:isoWeek.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3822,7 +4198,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad (GA Model)",
-        "description": "DCM ad name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3834,7 +4211,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad ID (GA Model)",
-        "description": "DCM ad ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3846,7 +4224,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type (GA Model)",
-        "description": "DCM ad type name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad type name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3858,7 +4237,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type ID",
-        "description": "DCM ad type ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM ad type ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3870,7 +4250,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser (GA Model)",
-        "description": "DCM advertiser name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM advertiser name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3882,7 +4263,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID (GA Model)",
-        "description": "DCM advertiser ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM advertiser ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3894,7 +4276,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign (GA Model)",
-        "description": "DCM campaign name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM campaign name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3906,7 +4289,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign ID (GA Model)",
-        "description": "DCM campaign ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM campaign ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3918,7 +4302,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative ID (GA Model)",
-        "description": "DCM creative ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3930,7 +4315,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative (GA Model)",
-        "description": "DCM creative name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3942,7 +4328,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Rendering ID (GA Model)",
-        "description": "DCM rendering ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM rendering ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3954,7 +4341,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type (GA Model)",
-        "description": "DCM creative type name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative type name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3966,7 +4354,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type ID (GA Model)",
-        "description": "DCM creative type ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative type ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3978,7 +4367,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Version (GA Model)",
-        "description": "DCM creative version of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM creative version of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -3990,7 +4380,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site (GA Model)",
-        "description": "Site name where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only)."
+        "description": "Site name where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4002,7 +4393,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site ID (GA Model)",
-        "description": "DCM site ID where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site ID where the DCM creative was shown and clicked on for the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4014,7 +4406,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement (GA Model)",
-        "description": "DCM site placement name of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site placement name of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4026,7 +4419,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement ID (GA Model)",
-        "description": "DCM site placement ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM site placement ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4038,7 +4432,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID (GA Model)",
-        "description": "DCM Floodlight configuration ID of the DCM click matching the Google Analytics session (premium only)."
+        "description": "DCM Floodlight configuration ID of the DCM click matching the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4050,7 +4445,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity",
-        "description": "DCM Floodlight activity name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4062,7 +4458,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity and Group",
-        "description": "DCM Floodlight activity name and group name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity name and group name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4074,7 +4471,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity Group",
-        "description": "DCM Floodlight activity group name associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity group name associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4086,7 +4484,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity Group ID",
-        "description": "DCM Floodlight activity group ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity group ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4098,7 +4497,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Activity ID",
-        "description": "DCM Floodlight activity ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight activity ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4110,7 +4510,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID",
-        "description": "DCM Floodlight advertiser ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight advertiser ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4122,7 +4523,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID",
-        "description": "DCM Floodlight configuration ID associated with the floodlight conversion (premium only)."
+        "description": "DCM Floodlight configuration ID associated with the floodlight conversion (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4134,7 +4536,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad",
-        "description": "DCM ad name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4146,7 +4549,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad ID (DFA Model)",
-        "description": "DCM ad ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4158,7 +4562,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type (DFA Model)",
-        "description": "DCM ad type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4170,7 +4575,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Ad Type ID (DFA Model)",
-        "description": "DCM ad type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM ad type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4182,7 +4588,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser (DFA Model)",
-        "description": "DCM advertiser name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM advertiser name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4194,7 +4601,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Advertiser ID (DFA Model)",
-        "description": "DCM advertiser ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM advertiser ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4206,7 +4614,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Attribution Type (DFA Model)",
-        "description": "There are two possible values: ClickThrough and ViewThrough. If the last DCM event associated with the Google Analytics session was a click, then the value will be ClickThrough. If the last DCM event associated with the Google Analytics session was an ad impression, then the value will be ViewThrough (premium only)."
+        "description": "There are two possible values: ClickThrough and ViewThrough. If the last DCM event associated with the Google Analytics session was a click, then the value will be ClickThrough. If the last DCM event associated with the Google Analytics session was an ad impression, then the value will be ViewThrough (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4218,7 +4627,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign (DFA Model)",
-        "description": "DCM campaign name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM campaign name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4230,7 +4640,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Campaign ID (DFA Model)",
-        "description": "DCM campaign ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM campaign ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4242,7 +4653,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative ID (DFA Model)",
-        "description": "DCM creative ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4254,7 +4666,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative (DFA Model)",
-        "description": "DCM creative name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4266,7 +4679,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Rendering ID (DFA Model)",
-        "description": "DCM rendering ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM rendering ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4278,7 +4692,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type (DFA Model)",
-        "description": "DCM creative type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative type name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4290,7 +4705,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Type ID (DFA Model)",
-        "description": "DCM creative type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative type ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4302,7 +4718,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Creative Version (DFA Model)",
-        "description": "DCM creative version of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM creative version of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4314,7 +4731,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site (DFA Model)",
-        "description": "Site name where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "Site name where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4326,7 +4744,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Site ID (DFA Model)",
-        "description": "DCM site ID where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site ID where the DCM creative was shown and clicked on for the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4338,7 +4757,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement (DFA Model)",
-        "description": "DCM site placement name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site placement name of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4350,7 +4770,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Placement ID (DFA Model)",
-        "description": "DCM site placement ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM site placement ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4362,7 +4783,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Floodlight Configuration ID (DFA Model)",
-        "description": "DCM Floodlight configuration ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only)."
+        "description": "DCM Floodlight configuration ID of the last DCM event (impression or click within the DCM lookback window) associated with the Google Analytics session (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4374,7 +4796,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Conversions",
-        "description": "The number of DCM Floodlight conversions (premium only)."
+        "description": "The number of DCM Floodlight conversions (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4386,7 +4809,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Revenue",
-        "description": "DCM Floodlight revenue (premium only)."
+        "description": "DCM Floodlight revenue (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4398,10 +4822,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Landing Page Group XX",
-        "description": "The first matching content group in a user's session.",
+        "description": "Content group of users' landing pages.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4416,7 +4841,8 @@
         "description": "Refers to content group that was visited before another content group.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4428,10 +4854,11 @@
         "group": "Content Grouping",
         "status": "PUBLIC",
         "uiName": "Page Group XX",
-        "description": "Content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/url regex match, or predefined rules.",
+        "description": "The content group on a property. A content group is a collection of content providing a logical structure that can be determined by tracking code or page title/URL regex match, or predefined rules.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4441,12 +4868,13 @@
         "type": "DIMENSION",
         "dataType": "STRING",
         "group": "Content Grouping",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "Next Page Group XX",
-        "description": "Refers to content group that was visited after another content group.",
+        "description": "This dimension is deprecated and will be removed soon. Please use ga:contentGroupXX instead.",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4458,8 +4886,8 @@
         "group": "Audience",
         "status": "PUBLIC",
         "uiName": "Age",
-        "description": "Age bracket of user.",
-        "allowedInSegments": "true"
+        "description": "Age bracket of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4472,8 +4900,8 @@
         "group": "Audience",
         "status": "DEPRECATED",
         "uiName": "Age",
-        "description": "Age bracket of user.",
-        "allowedInSegments": "true"
+        "description": "Age bracket of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4485,8 +4913,8 @@
         "group": "Audience",
         "status": "PUBLIC",
         "uiName": "Gender",
-        "description": "Gender of user.",
-        "allowedInSegments": "true"
+        "description": "Gender of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4499,8 +4927,8 @@
         "group": "Audience",
         "status": "DEPRECATED",
         "uiName": "Gender",
-        "description": "Gender of user.",
-        "allowedInSegments": "true"
+        "description": "Gender of users.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4513,7 +4941,7 @@
         "status": "PUBLIC",
         "uiName": "Other Category",
         "description": "Indicates that users are more likely to be interested in learning about the specified category, and more likely to be ready to purchase.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4526,7 +4954,7 @@
         "status": "PUBLIC",
         "uiName": "Affinity Category (reach)",
         "description": "Indicates that users are more likely to be interested in learning about the specified category.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4539,7 +4967,7 @@
         "status": "PUBLIC",
         "uiName": "In-Market Segment",
         "description": "Indicates that users are more likely to be ready to purchase products or services in the specified category.",
-        "allowedInSegments": "true"
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4552,7 +4980,8 @@
         "status": "PUBLIC",
         "uiName": "AdSense Revenue",
         "description": "The total revenue from AdSense ads.",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4564,8 +4993,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Ad Units Viewed",
-        "description": "The number of AdSense ad units viewed. An Ad unit is a set of ads displayed as a result of one piece of the AdSense ad code. Details: https://support.google.com/adsense/answer/32715?hl=en",
-        "allowedInSegments": "true"
+        "description": "The number of AdSense ad units viewed. An ad unit is a set of ads displayed as a result of one piece of the AdSense ad code. For details, see https://support.google.com/adsense/answer/32715?hl=en.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4577,8 +5007,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Impressions",
-        "description": "The number of AdSense ads viewed. Multiple ads can be displayed within an Ad Unit.",
-        "allowedInSegments": "true"
+        "description": "The number of AdSense ads viewed. Multiple ads can be displayed within an ad Unit.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4590,8 +5021,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Ads Clicked",
-        "description": "The number of times AdSense ads on your site were clicked.",
-        "allowedInSegments": "true"
+        "description": "The number of times AdSense ads on the site were clicked.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4603,8 +5035,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Page Impressions",
-        "description": "The number of pageviews during which an AdSense ad was displayed. A page impression can have multiple Ad Units.",
-        "allowedInSegments": "true"
+        "description": "The number of pageviews during which an AdSense ad was displayed. A page impression can have multiple ad Units.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4616,8 +5049,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense CTR",
-        "description": "The percentage of page impressions that resulted in a click on an AdSense ad.",
-        "calculation": "ga:adsenseAdsClicks/ga:adsensePageImpressions"
+        "description": "The percentage of page impressions resulted in a click on an AdSense ad.",
+        "calculation": "ga:adsenseAdsClicks/ga:adsensePageImpressions",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4629,8 +5063,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense eCPM",
-        "description": "The estimated cost per thousand page impressions. It is your AdSense Revenue per 1000 page impressions.",
-        "calculation": "ga:adsenseRevenue/(ga:adsensePageImpressions/1000)"
+        "description": "The estimated cost per thousand page impressions. It is the AdSense Revenue per 1,000 page impressions.",
+        "calculation": "ga:adsenseRevenue/(ga:adsensePageImpressions/1000)",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4642,8 +5077,9 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Exits",
-        "description": "The number of sessions that ended due to a user clicking on an AdSense ad.",
-        "allowedInSegments": "true"
+        "description": "The number of sessions ended due to a user clicking on an AdSense ad.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4655,7 +5091,8 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Viewable Impression %",
-        "description": "The percentage of impressions that were viewable."
+        "description": "The percentage of viewable impressions.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4667,7 +5104,221 @@
         "group": "Adsense",
         "status": "PUBLIC",
         "uiName": "AdSense Coverage",
-        "description": "The percentage of ad requests that returned at least one ad."
+        "description": "The percentage of ad requests that returned at least one ad.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxImpressions",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Impressions",
+        "description": "An Ad Exchange ad impression is reported whenever an individual ad is displayed on the website. For example, if a page with two ad units is viewed once, we'll display two impressions.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxCoverage",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Coverage",
+        "description": "Coverage is the percentage of ad requests that returned at least one ad. Generally, coverage can help identify sites where the Ad Exchange account isn't able to provide targeted ads. (Ad Impressions / Total Ad Requests) * 100",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxMonetizedPageviews",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Monetized Pageviews",
+        "description": "This measures the total number of pageviews on the property that were shown with an ad from the linked Ad Exchange account. Note that a single page can have multiple ad units.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxImpressionsPerSession",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Impressions / Session",
+        "description": "The ratio of Ad Exchange ad impressions to Analytics sessions (Ad Impressions / Analytics Sessions).",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxViewableImpressionsPercent",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Viewable Impressions %",
+        "description": "The percentage of viewable ad impressions. An impression is considered a viewable impression when it has appeared within users' browsers and has the opportunity to be seen.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxClicks",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Clicks",
+        "description": "The number of times AdX ads were clicked on the site.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxCTR",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX CTR",
+        "description": "The percentage of pageviews that resulted in a click on an Ad Exchange ad.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxRevenue",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Revenue",
+        "description": "The total estimated revenue from Ad Exchange ads.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxRevenuePer1000Sessions",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX Revenue / 1000 Sessions",
+        "description": "The total estimated revenue from Ad Exchange ads per 1,000 Analytics sessions. Note that this metric is based on sessions to the site, not on ad impressions.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:adxECPM",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ad Exchange",
+        "status": "PUBLIC",
+        "uiName": "AdX eCPM",
+        "description": "The effective cost per thousand pageviews. It is the Ad Exchange revenue per 1,000 pageviews.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:acquisitionCampaign",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Campaign",
+        "description": "The campaign through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionMedium",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Medium",
+        "description": "The medium through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionSource",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Source",
+        "description": "The source through which users were acquired, derived from users' first session.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionSourceMedium",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Source / Medium",
+        "description": "The combined value of ga:userAcquisitionSource and ga:acquisitionMedium.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:acquisitionTrafficChannel",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Acquisition Channel",
+        "description": "Traffic channel through which users were acquired. It is extracted from users' first session. Traffic channel is computed based on the default channel grouping rules (at view level if available) at the time of user acquisition.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:browserSize",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Platform or Device",
+        "status": "PUBLIC",
+        "uiName": "Browser Size",
+        "description": "The viewport size of users' browsers. A session-scoped dimension, browser size captures the initial dimensions of the viewport in pixels and is formatted as width x height, for example, 1920x960.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4679,7 +5330,8 @@
         "group": "Traffic Sources",
         "status": "PUBLIC",
         "uiName": "Campaign Code",
-        "description": "When using manual campaign tracking, the value of the utm_id campaign tracking parameter."
+        "description": "For manual campaign tracking, it is the value of the utm_id campaign tracking parameter.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4691,8 +5343,9 @@
         "group": "Channel Grouping",
         "status": "PUBLIC",
         "uiName": "Default Channel Grouping",
-        "description": "The default channel grouping that is shared within the View (Profile).",
-        "allowedInSegments": "true"
+        "description": "The default channel grouping shared within the View (Profile).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4704,8 +5357,75 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Checkout Options",
-        "description": "User options specified during the checkout process, e.g., FedEx, DHL, UPS for delivery options or Visa, MasterCard, AmEx for payment options. This dimension should be used along with ga:shoppingStage (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "User options specified during the checkout process, e.g., FedEx, DHL, UPS for delivery options; Visa, MasterCard, AmEx for payment options. This dimension should be used with ga:shoppingStage (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cityId",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "City ID",
+        "description": "Users' city ID, derived from their IP addresses or Geographical IDs. The city IDs are the same as the Criteria IDs found at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cohort",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Cohort",
+        "description": "Name of the cohort to which a user belongs. Depending on how cohorts are defined, a user can belong to multiple cohorts, similar to how a user can belong to multiple segments.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthDay",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Day",
+        "description": "Day offset relative to the cohort definition date. For example, if a cohort is defined with the first visit date as 2015-09-01, then for the date 2015-09-04, ga:cohortNthDay will be 3.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthMonth",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Month",
+        "description": "Month offset relative to the cohort definition date. The semantics of this dimension differs based on whether lifetime value is requested or not. For a cohorts report not requesting lifetime value: This is the week offset from the cohort definition start date. For example, if cohort is defined as 2015-09-01 <= first session date <= 2015-09-30. Then, for 2015-09-01 <= date <= 2015-09-30, ga:cohortNthMonth = 0. 2015-10-01 <= date <= 2015-10-31, ga:cohortNthMonth = 2. and so on. For a cohorts request requesting lifetime value: ga:cohortNthMonth is calculated relative to the users acquisition date. It is not dependent on the cohort definition date. For example, if we define a cohort as 2015-10-01 <= first session date <= 2015-09-30. And a user was acquired on 2015-09-04. Then, for 2015-09-04 <= date <= 2015-10-04, ga:cohortNthMonth = 0 2015-10-04 <= date <= 2015-11-04, ga:cohortNthMonth = 1, and so on.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortNthWeek",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Week",
+        "description": "Week offset relative to the cohort definition date. The semantics of this dimension differs based on whether lifetime value is requested or not. For a cohorts report not requesting lifetime value: This is the week offset from the cohort definition start date. For example, if cohort is defined as 2015-09-01 <= first session date <= 2015-09-07. Then, for 2015-09-01 <= date <= 2015-09-07, ga:cohortNthWeek = 0. 2015-09-08 <= date <= 2015-09-14, ga:cohortNthWeek = 1. etc. For a cohorts request requesting lifetime value: ga:cohortNthWeek is calculated relative to the users acquisition date. It is not dependent on the cohort definition date. For example, if we define a cohort as 2015-09-01 <= first session date <= 2015-09-07. And a user was acquired on 2015-09-04. Then, for 2015-09-04 <= date<= 2015-09-10, ga:cohortNthWeek = 0 2015-09-11 <= date <= 2015-09-17, ga:cohortNthWeek = 1",
+        "addedInApiVersion": "4"
       }
     },
     {
@@ -4717,7 +5437,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Correlation Model ID",
-        "description": "Correlation Model ID for related products."
+        "description": "Correlation Model ID for related products.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:countryIsoCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Country ISO Code",
+        "description": "Users' country's ISO code (in ISO-3166-1 alpha-2 format), derived from their IP addresses or Geographical IDs. For example, BR for Brazil, CA for Canada.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:dataSource",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Platform or Device",
+        "status": "PUBLIC",
+        "uiName": "Data Source",
+        "description": "The data source of a hit. By default, hits sent from ga.js and analytics.js are reported as \"web\" and hits sent from the mobile SDKs are reported as \"app\". These values can be overridden in the Measurement Protocol.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4730,7 +5479,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Creative",
         "description": "The creative content designed for a promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4743,7 +5493,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion ID",
         "description": "The ID of the promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4756,7 +5507,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Name",
         "description": "The name of the promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4769,7 +5521,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Position",
         "description": "The position of the promotion on the web page or application screen (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4781,7 +5534,8 @@
         "group": "Adwords",
         "status": "PUBLIC",
         "uiName": "TrueView Video Ad",
-        "description": "'Yes' or 'No' - Indicates whether the ad is an AdWords TrueView video ad."
+        "description": "A boolean, Yes or No, indicating whether the ad is an AdWords TrueView video ad.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4793,7 +5547,8 @@
         "group": "Time",
         "status": "PUBLIC",
         "uiName": "Hour Index",
-        "description": "Index for each hour in the specified date range. Index for the first hour of first day (i.e., start-date) in the date range is 0, 1 for the next hour, and so on."
+        "description": "The index for each hour in the specified date range. The index for the first hour of the first day (i.e., start-date) in the date range is 0, for the next hour 1, and so on.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4806,7 +5561,8 @@
         "status": "PUBLIC",
         "uiName": "Order Coupon Code",
         "description": "Code for the order-level coupon (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4819,7 +5575,8 @@
         "status": "PUBLIC",
         "uiName": "Product Brand",
         "description": "The brand name under which the product is sold (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4832,7 +5589,8 @@
         "status": "PUBLIC",
         "uiName": "Product Category (Enhanced Ecommerce)",
         "description": "The hierarchical category in which the product is classified (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4847,7 +5605,8 @@
         "description": "Level (1-5) in the product category hierarchy, starting from the top (Enhanced Ecommerce).",
         "minTemplateIndex": "1",
         "maxTemplateIndex": "5",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4860,7 +5619,8 @@
         "status": "PUBLIC",
         "uiName": "Product Coupon Code",
         "description": "Code for the product-level coupon (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4873,7 +5633,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Name",
         "description": "The name of the product list in which the product appears (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4886,7 +5647,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Position",
         "description": "The position of the product in the product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4898,8 +5660,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Variant",
-        "description": "The specific variation of a product, e.g., XS, S, M, L for size or Red, Blue, Green, Black for color (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "The specific variation of a product, e.g., XS, S, M, L for size; or Red, Blue, Green, Black for color (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4911,7 +5674,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product ID",
-        "description": "ID of the product being queried."
+        "description": "ID of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4923,7 +5687,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Name",
-        "description": "Name of the product being queried."
+        "description": "Name of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4935,7 +5700,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Variation",
-        "description": "Variation of the product being queried."
+        "description": "Variation of the product being queried.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:regionId",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Region ID",
+        "description": "Users' region ID, derived from their IP addresses or Geographical IDs. In U.S., a region is a state, New York, for example. The region IDs are the same as the Criteria IDs listed at https://developers.google.com/analytics/devguides/collection/protocol/v1/geoid.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:regionIsoCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Region ISO Code",
+        "description": "Users' region ISO code in ISO-3166-2 format, derived from their IP addresses or Geographical IDs.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4947,7 +5741,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product ID",
-        "description": "ID of the related product."
+        "description": "ID of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4959,7 +5754,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Name",
-        "description": "Name of the related product."
+        "description": "Name of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4971,7 +5767,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Variation",
-        "description": "Variation of the related product."
+        "description": "Variation of the related product.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4984,7 +5781,21 @@
         "status": "PUBLIC",
         "uiName": "Shopping Stage",
         "description": "Various stages of the shopping experience that users completed in a session, e.g., PRODUCT_VIEW, ADD_TO_CART, CHECKOUT, etc. (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:subContinentCode",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "DIMENSION",
+        "dataType": "STRING",
+        "group": "Geo Network",
+        "status": "PUBLIC",
+        "uiName": "Sub Continent Code",
+        "description": "Users' sub-continent code in UN M.49 format, derived from their IP addresses or Geographical IDs. For example, 061 for Polynesia, 154 for Northern Europe.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -4996,7 +5807,8 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Buy-to-Detail Rate",
-        "description": "Unique purchases divided by views of product detail pages (Enhanced Ecommerce)."
+        "description": "Unique purchases divided by views of product detail pages (Enhanced Ecommerce).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5008,7 +5820,229 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Cart-to-Detail Rate",
-        "description": "Product adds divided by views of product details (Enhanced Ecommerce)."
+        "description": "Product adds divided by views of product details (Enhanced Ecommerce).",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:cohortActiveUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Users",
+        "description": "This metric is relevant in the context of ga:cohortNthDay/ga:cohortNthWeek/ga:cohortNthMonth. It indicates the number of users in the cohort who are active in the time window corresponding to the cohort nth day/week/month. For example, for ga:cohortNthWeek = 1, number of users (in the cohort) who are active in week 1. If a request doesn't have any of ga:cohortNthDay/ga:cohortNthWeek/ga:cohortNthMonth, this metric will have the same value as ga:cohortTotalUsers.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortAppviewsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Appviews per User",
+        "description": "App views per user for a cohort.",
+        "calculation": "ga:appviews / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortAppviewsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Appviews Per User (LTV)",
+        "description": "App views per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:appviews / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortGoalCompletionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Goal Completions per User",
+        "description": "Goal completions per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:goalCompletionsAll / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortGoalCompletionsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Goal Completions Per User (LTV)",
+        "description": "Goal completions per user for a cohort.",
+        "calculation": "ga:goalCompletionsAll / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortPageviewsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Pageviews per User",
+        "description": "Pageviews per user for a cohort.",
+        "calculation": "ga:pageviews / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortPageviewsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Pageviews Per User (LTV)",
+        "description": "Pageviews per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:pageviews / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRetentionRate",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "User Retention",
+        "description": "Cohort retention rate.",
+        "calculation": "ga:cohortActiveUsers / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRevenuePerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Revenue per User",
+        "description": "Revenue per user for a cohort.",
+        "calculation": "ga:transactions / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortRevenuePerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Revenue Per User (LTV)",
+        "description": "Revenue per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:transactions / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionDurationPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "TIME",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Session Duration per User",
+        "description": "Session duration per user for a cohort.",
+        "calculation": "ga:sessionDuration / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionDurationPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "TIME",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Session Duration Per User (LTV)",
+        "description": "Session duration per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:sessionDuration / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Sessions per User",
+        "description": "Sessions per user for a cohort.",
+        "calculation": "ga:sessions / ga:cohortTotalUsers",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortSessionsPerUserWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Sessions Per User (LTV)",
+        "description": "Sessions per user for the acquisition dimension for a cohort.",
+        "calculation": "ga:sessions / ga:cohortTotalUsersWithLifetimeCriteria",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortTotalUsers",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Total Users",
+        "description": "Number of users belonging to the cohort, also known as cohort size.",
+        "addedInApiVersion": "4"
+      }
+    },
+    {
+      "id": "ga:cohortTotalUsersWithLifetimeCriteria",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "INTEGER",
+        "group": "Lifetime Value and Cohorts",
+        "status": "PUBLIC",
+        "uiName": "Users",
+        "description": "This is relevant in the context of a request which has the dimensions ga:acquisitionTrafficChannel/ga:acquisitionSource/ga:acquisitionMedium/ga:acquisitionCampaign. It represents the number of users in the cohorts who are acquired through the current channel/source/medium/campaign. For example, for ga:acquisitionTrafficChannel=Direct, it represents the number users in the cohort, who were acquired directly. If none of these mentioned dimensions are present, then its value is equal to ga:cohortTotalUsers.",
+        "addedInApiVersion": "4"
       }
     },
     {
@@ -5020,7 +6054,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Correlation Score",
-        "description": "Correlation Score for related products."
+        "description": "Correlation Score for related products.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5032,7 +6067,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA CPC",
-        "description": "DCM Cost Per Click (premium only)."
+        "description": "DCM Cost Per Click (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5044,7 +6080,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA CTR",
-        "description": "DCM Click Through Rate (premium only)."
+        "description": "DCM Click Through Rate (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5056,7 +6093,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Clicks",
-        "description": "DCM Total Clicks (premium only)."
+        "description": "DCM Total Clicks (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5068,7 +6106,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Cost",
-        "description": "DCM Total Cost (premium only)."
+        "description": "DCM Total Cost (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5080,7 +6119,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA Impressions",
-        "description": "DCM Total Impressions (premium only)."
+        "description": "DCM Total Impressions (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5090,9 +6130,23 @@
         "type": "METRIC",
         "dataType": "PERCENT",
         "group": "DoubleClick Campaign Manager",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "DFA Margin",
-        "description": "DCM Margin (premium only)."
+        "description": "This metric is deprecated and will be removed soon. Please use ga:dcmROAS instead.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:dcmROAS",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "PERCENT",
+        "group": "DoubleClick Campaign Manager",
+        "status": "PUBLIC",
+        "uiName": "DFA ROAS",
+        "description": "DCM Return On Ad Spend (ROAS) (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5102,9 +6156,10 @@
         "type": "METRIC",
         "dataType": "PERCENT",
         "group": "DoubleClick Campaign Manager",
-        "status": "PUBLIC",
+        "status": "DEPRECATED",
         "uiName": "DFA ROI",
-        "description": "DCM Return On Investment (premium only)."
+        "description": "This metric is deprecated and will be removed soon. Please use ga:dcmROAS instead.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5116,7 +6171,8 @@
         "group": "DoubleClick Campaign Manager",
         "status": "PUBLIC",
         "uiName": "DFA RPC",
-        "description": "DCM Revenue Per Click (premium only)."
+        "description": "DCM Revenue Per Click (premium only).",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5128,8 +6184,9 @@
         "group": "Session",
         "status": "PUBLIC",
         "uiName": "Hits",
-        "description": "Total number of hits sent to Google Analytics. This metric sums all hit types (e.g. pageview, event, timing, etc.).",
-        "allowedInSegments": "true"
+        "description": "Total number of hits for the view (profile). This metric sums all hit types, including pageview, custom event, ecommerce, and other types. Because this metric is based on the view (profile), not on the property, it is not the same as the property's hit volume.",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5142,7 +6199,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion CTR",
         "description": "The rate at which users clicked through to view the internal promotion (ga:internalPromotionClicks / ga:internalPromotionViews) - (Enhanced Ecommerce).",
-        "calculation": "ga:internalPromotionClicks / ga:internalPromotionViews"
+        "calculation": "ga:internalPromotionClicks / ga:internalPromotionViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5155,7 +6213,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Clicks",
         "description": "The number of clicks on an internal promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5168,7 +6227,8 @@
         "status": "PUBLIC",
         "uiName": "Internal Promotion Views",
         "description": "The number of views of an internal promotion (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5180,8 +6240,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Product Refund Amount",
-        "description": "Refund amount for a given product in the local currency (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Refund amount in local currency for a given product (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5193,8 +6254,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Local Refund Amount",
-        "description": "Total refund amount for the transaction in the local currency (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Total refund amount in local currency for the transaction (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5207,7 +6269,8 @@
         "status": "PUBLIC",
         "uiName": "Product Adds To Cart",
         "description": "Number of times the product was added to the shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5220,7 +6283,8 @@
         "status": "PUBLIC",
         "uiName": "Product Checkouts",
         "description": "Number of times the product was included in the check-out process (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5233,7 +6297,8 @@
         "status": "PUBLIC",
         "uiName": "Product Detail Views",
         "description": "Number of times users viewed the product-detail page (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5246,7 +6311,8 @@
         "status": "PUBLIC",
         "uiName": "Product List CTR",
         "description": "The rate at which users clicked through on the product in a product list (ga:productListClicks / ga:productListViews) - (Enhanced Ecommerce).",
-        "calculation": "ga:productListClicks / ga:productListViews"
+        "calculation": "ga:productListClicks / ga:productListViews",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5259,7 +6325,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Clicks",
         "description": "Number of times users clicked the product when it appeared in the product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5272,7 +6339,8 @@
         "status": "PUBLIC",
         "uiName": "Product List Views",
         "description": "Number of times the product appeared in a product list (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5285,7 +6353,8 @@
         "status": "PUBLIC",
         "uiName": "Product Refund Amount",
         "description": "Total refund amount associated with the product (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5298,7 +6367,8 @@
         "status": "PUBLIC",
         "uiName": "Product Refunds",
         "description": "Number of times a refund was issued for the product (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5310,8 +6380,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Product Removes From Cart",
-        "description": "Number of times the product was removed from shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Number of times the product was removed from the shopping cart (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5324,7 +6395,8 @@
         "status": "PUBLIC",
         "uiName": "Product Revenue per Purchase",
         "description": "Average product revenue per purchase (commonly used with Product Coupon Code) (ga:itemRevenue / ga:uniquePurchases) - (Enhanced Ecommerce).",
-        "calculation": "ga:itemRevenue / ga:uniquePurchases"
+        "calculation": "ga:itemRevenue / ga:uniquePurchases",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5337,7 +6409,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Added To Cart",
         "description": "Number of product units added to the shopping cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5350,7 +6423,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Checked Out",
         "description": "Number of product units included in check out (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5363,7 +6437,8 @@
         "status": "PUBLIC",
         "uiName": "Quantity Refunded",
         "description": "Number of product units refunded (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5375,8 +6450,9 @@
         "group": "Ecommerce",
         "status": "PUBLIC",
         "uiName": "Quantity Removed From Cart",
-        "description": "Number of product units removed from cart (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "description": "Number of product units removed from a shopping cart (Enhanced Ecommerce).",
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5388,7 +6464,8 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Queried Product Quantity",
-        "description": "Quantity of the product being queried."
+        "description": "Quantity of the product being queried.",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5401,7 +6478,8 @@
         "status": "PUBLIC",
         "uiName": "Refund Amount",
         "description": "Currency amount refunded for a transaction (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5413,7 +6491,36 @@
         "group": "Related Products",
         "status": "PUBLIC",
         "uiName": "Related Product Quantity",
-        "description": "Quantity of the related product."
+        "description": "Quantity of the related product.",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:revenuePerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "CURRENCY",
+        "group": "Ecommerce",
+        "status": "PUBLIC",
+        "uiName": "Revenue per User",
+        "description": "The total sale revenue (excluding shipping and tax) of the transaction divided by the total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:sessionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "User",
+        "status": "PUBLIC",
+        "uiName": "Number of Sessions per User",
+        "description": "The total number of sessions divided by the total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     },
     {
@@ -5426,7 +6533,22 @@
         "status": "PUBLIC",
         "uiName": "Refunds",
         "description": "Number of refunds that have been issued (Enhanced Ecommerce).",
-        "allowedInSegments": "true"
+        "allowedInSegments": "true",
+        "addedInApiVersion": "3"
+      }
+    },
+    {
+      "id": "ga:transactionsPerUser",
+      "kind": "analytics#column",
+      "attributes": {
+        "type": "METRIC",
+        "dataType": "FLOAT",
+        "group": "Ecommerce",
+        "status": "PUBLIC",
+        "uiName": "Transactions per User",
+        "description": "Total number of transactions divided by total number of users.",
+        "allowedInSegments": "false",
+        "addedInApiVersion": "3"
       }
     }
   ]

--- a/test/metadata/metadata.js
+++ b/test/metadata/metadata.js
@@ -18,28 +18,34 @@ var Metadata = require('../../lib/metadata/metadata');
 
 var columns = require('../_fixtures/metadata.json').items;
 
+var integerColumns = columns.filter(function(column) {
+  return column.attributes.dataType == 'INTEGER';
+});
+
 var metrics = columns.filter(function(column) {
   return column.attributes.type == 'METRIC';
 });
 
-var publicMetrics = metrics.filter(function(metric) {
-  return metric.attributes.status == 'PUBLIC';
+var v3publicMetrics = metrics.filter(function(metric) {
+  return metric.attributes.status == 'PUBLIC' &&
+      metric.attributes.addedInApiVersion === '3';
 });
 
-var deprecatedMetrics = metrics.filter(function(metric) {
-  return metric.attributes.status == 'DEPRECATED';
+var integerMetrics = metrics.filter(function(metric) {
+  return metric.attributes.dataType == 'INTEGER';
 });
 
 var dimensions = columns.filter(function(column) {
   return column.attributes.type == 'DIMENSION';
 });
 
-var publicDimensions = dimensions.filter(function(dimension) {
-  return dimension.attributes.status == 'PUBLIC';
+var v3publicDimensions = dimensions.filter(function(dimension) {
+  return dimension.attributes.status == 'PUBLIC' &&
+      dimension.attributes.addedInApiVersion === '3';
 });
 
-var deprecatedDimensions = dimensions.filter(function(dimension) {
-  return dimension.attributes.status == 'DEPRECATED';
+var integerDimensions = dimensions.filter(function(dimension) {
+  return dimension.attributes.dataType == 'INTEGER';
 });
 
 
@@ -51,26 +57,53 @@ describe('Metadata', function() {
     it('returns the full list of columns.', function() {
       assert.deepEqual(metadata.all(), columns);
     });
+
+    it('accepts an optional filter argument object.', function() {
+      var filter = {type: 'METRIC', status: 'PUBLIC', addedInApiVersion: '3'};
+      assert.deepEqual(metadata.all(filter), v3publicMetrics);
+    });
+
+    it('accepts an optional filter argument function.', function() {
+      var filter = function(attributes) {
+        return attributes.dataType == 'INTEGER';
+      };
+      assert.deepEqual(metadata.all(filter), integerColumns);
+    });
   });
 
   describe('#allMetrics', function() {
-    it('gets only the columns that are metrics, optionally filtered' +
-        'by a status parameter.', function() {
-
+    it('gets only the columns that are metrics', function() {
       assert.deepEqual(metadata.allMetrics(), metrics);
-      assert.deepEqual(metadata.allMetrics('public'), publicMetrics);
-      assert.deepEqual(metadata.allMetrics('deprecated'), deprecatedMetrics);
+    });
+
+    it('accepts an optional filter argument.', function() {
+      var filter = {addedInApiVersion: '3', status: 'PUBLIC'};
+      assert.deepEqual(metadata.allMetrics(filter), v3publicMetrics);
+    });
+
+    it('accepts an optional filter argument function.', function() {
+      var filter = function(attributes) {
+        return attributes.dataType == 'INTEGER';
+      };
+      assert.deepEqual(metadata.allMetrics(filter), integerMetrics);
     });
   });
 
   describe('#allDimensions', function() {
-    it('gets only the columns that are dimensions, optionally filtered' +
-        'by a status parameter.', function() {
-
+    it('gets only the columns that are dimensions', function() {
       assert.deepEqual(metadata.allDimensions(), dimensions);
-      assert.deepEqual(metadata.allDimensions('public'), publicDimensions);
-      assert.deepEqual(metadata.allDimensions('deprecated'),
-          deprecatedDimensions);
+    });
+
+    it('accepts an optional filter argument.', function() {
+      var filter = {addedInApiVersion: '3', status: 'PUBLIC'};
+      assert.deepEqual(metadata.allDimensions(filter), v3publicDimensions);
+    });
+
+    it('accepts an optional filter argument function.', function() {
+      var filter = function(attributes) {
+        return attributes.dataType == 'INTEGER';
+      };
+      assert.deepEqual(metadata.allDimensions(filter), integerDimensions);
     });
   });
 


### PR DESCRIPTION
This change gives developers more flexibility in they can filter dimensions and metrics returned by the API. The change was motivated by the new attribute `addedInApiVersion`.

After this change, developers can explicitly match an API version using an object filter:

``` js
columns.allMetrics({status: 'PUBLIC', addedInApiVersion: '3'});
```

Or they can use logic to, for example, only include columns added in an API version greater than X:

``` js
columns.allMetrics(function(attributes) {
  return attributes.status == 'PUBLIC' && attributes.addedInApiVersion > 3;
});
```
